### PR TITLE
70/fix: não mostrar referências vazias #70

### DIFF
--- a/src/components/PageElements/Content/DetailingTopicContent/index.tsx
+++ b/src/components/PageElements/Content/DetailingTopicContent/index.tsx
@@ -1,15 +1,15 @@
-import React from "react";
-import { Grid } from "@mui/material";
-import { BreadCrumb } from "@/components/BreadCrumb";
-import { Title } from "@/components/title";
-import { ApiResponse, DataItem, TopicField } from "@/types/type";
-import { DescriptionReference } from "@/components/Description/DescriptionReference";
-import { ContainerCardsExercises } from "../../Container/ContainerCardsExercises";
-import { DescriptionWithVideo } from "@/components/Description/DescriptionWithVideo";
+import React from "react"
+import { Grid } from "@mui/material"
+import { BreadCrumb } from "@/components/BreadCrumb"
+import { Title } from "@/components/title"
+import { ApiResponse, DataItem, TopicField } from "@/types/type"
+import { DescriptionReference } from "@/components/Description/DescriptionReference"
+import { ContainerCardsExercises } from "../../Container/ContainerCardsExercises"
+import { DescriptionWithVideo } from "@/components/Description/DescriptionWithVideo"
 
 interface DetailingContentProps {
-  data: ApiResponse;
-  id: string;
+  data: ApiResponse
+  id: string
 }
 
 const TopicContent: React.FC<{ field: TopicField }> = ({ field }) => (

--- a/src/components/PageElements/Content/DetailingTopicContent/index.tsx
+++ b/src/components/PageElements/Content/DetailingTopicContent/index.tsx
@@ -18,23 +18,40 @@ const TopicContent: React.FC<{ field: TopicField }> = ({ field }) => (
       <BreadCrumb />
       <Title text={field.title} />
     </Grid>
-    <DescriptionWithVideo textDescription={field.description} textVideo={field.videoDescription} title={field.video} videoLink={field.videoLink} references={field.videoReference} />
+    <DescriptionWithVideo
+      textDescription={field.description}
+      textVideo={field.videoDescription}
+      title={field.video}
+      videoLink={field.videoLink}
+      references={field.videoReference}
+    />
     <Grid item xl={12} lg={9} md={6} sm={3}>
       <Title text={"Exercícios"} />
     </Grid>
     <ContainerCardsExercises
       exercises={field.exercises}
       exercisesDescription={field.exercisesDescription}
-      exercisesInfo={field.exercisesInfo} />
-    <Grid item xl={12} lg={9} md={6} sm={3}>
-      <Title text={"Referências"} />
-    </Grid>
-    <DescriptionReference text={field.references} />
+      exercisesInfo={field.exercisesInfo}
+    />
+
+    {field.references && field.references.trim() != "" && (
+      <>
+        <Grid item xl={12} lg={9} md={6} sm={3}>
+          <Title text={"Referências"} />
+        </Grid>
+        <DescriptionReference text={field.references} />
+      </>
+    )}
   </>
 )
 
-export const DetailingTopicContent: React.FC<DetailingContentProps> = ({ data, id }) => {
-  const filteredData = data?.data.filter((element: DataItem) => element.id === id.split("-")[0]);
+export const DetailingTopicContent: React.FC<DetailingContentProps> = ({
+  data,
+  id,
+}) => {
+  const filteredData = data?.data.filter(
+    (element: DataItem) => element.id === id.split("-")[0]
+  )
 
   return (
     <>
@@ -42,5 +59,5 @@ export const DetailingTopicContent: React.FC<DetailingContentProps> = ({ data, i
         <TopicContent key={element.id} field={element.field as TopicField} />
       ))}
     </>
-  );
-};
+  )
+}


### PR DESCRIPTION
# <70> - fix: não mostrar referências vazias

  
### 🆙 CHANGELOG

- Removemos o componente de referencia, caso não seja adicionada uma referencia no stackby 
- Removemos os ; para ficar nos padrões do coding style 

## ⚠️ Me certifico que:


- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:


- [ ] Verificar se main esta atualizada
- [ ] Vá na branch 70/fix-nao-mostrar-referencias-vazias
- [ ] Remova uma referencia do stackby
- [ ] Verificar se o componente referencias foi removido
- [ ] Aplicação não deve conter nenhum erro, warning ou console.log
- [ ] Alteração proposta no card foi implementada
