### PR TITLE
76/fix arrumar hierarquia das tags de titulos

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,21 @@
 "use client"
-import { Box } from "@mui/material";
+import { Box } from "@mui/material"
+import { useRouter } from "next/navigation"
+import { useEffect, useState } from "react"
 
 export default function Home() {
-  return (
-    <Box>
-    </Box>
-  );
+  const router = useRouter()
+  const [isMounted, setIsMounted] = useState<Boolean>(false)
+
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
+
+  useEffect(() => {
+    if (isMounted) {
+      router.push("/Nivelamento")
+    }
+  }, [isMounted, router])
+
+  return <Box></Box>
 }

--- a/src/components/BaseCard/index.tsx
+++ b/src/components/BaseCard/index.tsx
@@ -1,19 +1,19 @@
-import { CardActionArea, CardActions, ThemeProvider } from '@mui/material';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
-import CardMedia from '@mui/material/CardMedia';
-import Typography from '@mui/material/Typography';
-import { useRouter } from 'next/navigation';
-import * as React from 'react';
-import { theme } from '../../app/config/theme';
-import { ClickButton } from '../ClickButton';
+import { CardActionArea, CardActions } from "@mui/material"
+import Card from "@mui/material/Card"
+import CardContent from "@mui/material/CardContent"
+import CardMedia from "@mui/material/CardMedia"
+import Typography from "@mui/material/Typography"
+import { useRouter } from "next/navigation"
+import * as React from "react"
+import { theme } from "../../app/config/theme"
+import { ClickButton } from "../ClickButton"
 
 interface CardProps{
-    title: string;
-    description?: string;
-    textImage?: string; 
-    image?: string;
-    route: string;
+    title: string
+    description?: string
+    textImage?: string 
+    image?: string
+    route: string
 }
 
 const cardStyles = {
@@ -45,7 +45,7 @@ export const BaseCard: React.FC<CardProps> = ({title, description, textImage, im
                 />
             )}
                 <CardContent sx={theme.customStyles.cardContent}> 
-                    <Typography gutterBottom variant="h2" component="div" sx={theme.customStyles.cardTitle}>
+                    <Typography gutterBottom variant="h2" sx={theme.customStyles.cardTitle}>
                         {title}
                     </Typography>
                     <Typography  variant="body1" sx={cardStyles}>
@@ -57,5 +57,5 @@ export const BaseCard: React.FC<CardProps> = ({title, description, textImage, im
                 <ClickButton title="Entrar" click={() => handleClick(route)}  />
             </CardActions>
         </Card>
-    );
+    )
 }

--- a/src/components/ButtonCard/index.tsx
+++ b/src/components/ButtonCard/index.tsx
@@ -1,16 +1,15 @@
-import * as React from 'react';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
-import Typography from '@mui/material/Typography';
-import { CardActionArea, CardActions } from '@mui/material';
-import StatusSelect from '../StatusSelect';
-import { useRouter } from 'next/navigation';
-import { theme } from '../../app/config/theme';
+import * as React from "react"
+import Card from "@mui/material/Card"
+import CardContent from "@mui/material/CardContent"
+import Typography from "@mui/material/Typography"
+import { CardActionArea, CardActions } from "@mui/material"
+import { useRouter } from "next/navigation"
+import { theme } from "../../app/config/theme"
 
 interface ButtonCardProps {
-    title: string;
-    description: string;
-    route: string;
+    title: string
+    description: string
+    route: string
 }
 
 const cardStyles = {
@@ -32,7 +31,7 @@ export const ButtonCard: React.FC<ButtonCardProps> = ({ title, description, rout
             <Card sx={theme.customStyles.cardButtonContainer}>
                 <CardActionArea onClick={() => handleClick(route)} sx={{height: "100%"}}>
                     <CardContent sx={theme.customStyles.cardButtonContent}>
-                        <Typography gutterBottom variant="h2" component="div" sx={theme.customStyles.cardTitle}>
+                        <Typography gutterBottom variant="h2" sx={theme.customStyles.cardTitle}>
                             {title}
                         </Typography>
                         <Typography variant="body1" sx={cardStyles}>
@@ -41,5 +40,5 @@ export const ButtonCard: React.FC<ButtonCardProps> = ({ title, description, rout
                     </CardContent>
                 </CardActionArea>
             </Card>
-    );
+    )
 }

--- a/src/components/PageElements/Content/DetailingTopicContent/index.tsx
+++ b/src/components/PageElements/Content/DetailingTopicContent/index.tsx
@@ -1,15 +1,15 @@
-import React from "react";
-import { Grid } from "@mui/material";
-import { BreadCrumb } from "@/components/BreadCrumb";
-import { Title } from "@/components/title";
-import { ApiResponse, DataItem, TopicField } from "@/types/type";
-import { DescriptionReference } from "@/components/Description/DescriptionReference";
-import { ContainerCardsExercises } from "../../Container/ContainerCardsExercises";
-import { DescriptionWithVideo } from "@/components/Description/DescriptionWithVideo";
+import React from "react"
+import { Grid } from "@mui/material"
+import { BreadCrumb } from "@/components/BreadCrumb"
+import { Title } from "@/components/title"
+import { ApiResponse, DataItem, TopicField } from "@/types/type"
+import { DescriptionReference } from "@/components/Description/DescriptionReference"
+import { ContainerCardsExercises } from "../../Container/ContainerCardsExercises"
+import { DescriptionWithVideo } from "@/components/Description/DescriptionWithVideo"
 
 interface DetailingContentProps {
-  data: ApiResponse;
-  id: string;
+  data: ApiResponse
+  id: string
 }
 
 const TopicContent: React.FC<{ field: TopicField }> = ({ field }) => (

--- a/src/components/PageElements/Content/DetailingTopicContent/index.tsx
+++ b/src/components/PageElements/Content/DetailingTopicContent/index.tsx
@@ -18,23 +18,40 @@ const TopicContent: React.FC<{ field: TopicField }> = ({ field }) => (
       <BreadCrumb />
       <Title text={field.title} />
     </Grid>
-    <DescriptionWithVideo textDescription={field.description} textVideo={field.videoDescription} title={field.video} videoLink={field.videoLink} references={field.videoReference} />
+    <DescriptionWithVideo
+      textDescription={field.description}
+      textVideo={field.videoDescription}
+      title={field.video}
+      videoLink={field.videoLink}
+      references={field.videoReference}
+    />
     <Grid item xl={12} lg={9} md={6} sm={3}>
       <Title text={"Exercícios"} />
     </Grid>
     <ContainerCardsExercises
       exercises={field.exercises}
       exercisesDescription={field.exercisesDescription}
-      exercisesInfo={field.exercisesInfo} />
-    <Grid item xl={12} lg={9} md={6} sm={3}>
-      <Title text={"Referências"} />
-    </Grid>
-    <DescriptionReference text={field.references} />
+      exercisesInfo={field.exercisesInfo}
+    />
+
+    {field.references && field.references.trim() != "" && (
+      <>
+        <Grid item xl={12} lg={9} md={6} sm={3}>
+          <Title text={"Referências"} />
+        </Grid>
+        <DescriptionReference text={field.references} />
+      </>
+    )}
   </>
 )
 
-export const DetailingTopicContent: React.FC<DetailingContentProps> = ({ data, id }) => {
-  const filteredData = data?.data.filter((element: DataItem) => element.id === id.split("-")[0]);
+export const DetailingTopicContent: React.FC<DetailingContentProps> = ({
+  data,
+  id,
+}) => {
+  const filteredData = data?.data.filter(
+    (element: DataItem) => element.id === id.split("-")[0]
+  )
 
   return (
     <>
@@ -42,5 +59,5 @@ export const DetailingTopicContent: React.FC<DetailingContentProps> = ({ data, i
         <TopicContent key={element.id} field={element.field as TopicField} />
       ))}
     </>
-  );
-};
+  )
+}

--- a/src/components/title/index.tsx
+++ b/src/components/title/index.tsx
@@ -1,8 +1,8 @@
-'use client'
+"use client"
 import React from "react"
 import Typography from "@mui/material/Typography"
 import { theme, ThemeConfig } from "../../app/config/theme"
-import { Box, Grid } from "@mui/material"
+import { Grid } from "@mui/material"
 
 interface TitleProps {
     text: string
@@ -14,7 +14,6 @@ export const Title: React.FC<TitleProps> = ({ text }) => {
             <Grid container>  
                 <Typography
                     variant="h1"
-                    component="div"
                     sx={theme.customStyles.title}>
                     {text}
                 </Typography>


### PR DESCRIPTION
# <76> - fix arrumar hierarquia das tags de titulos

  
### 🆙 CHANGELOG


- Correções dos componentes title, baseCard, buttonCard.
- Ajustes seguindo o coding styles, troca de aspas simples por aspas duplas, remoção dos imports não utilizados e remoção dos ;

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:


- [ ] Verificar se a main esta atualizada
- [ ] Vá para branch 76/fix-arrumar-hierarquia-das-tags-de-titulos
- [ ] Verificar no VSCode os componentes title, baseCard, buttonCard
- [ ] Verificar no VSCode a troca das aspas a remoção dos imports e ;
- [ ] Verificar no navegador se quebrou algum componente
- [ ] Aplicação não deve conter nenhum erro, warning ou console.log
- [ ] Alteração proposta no card foi implementada
