### PR TITLE
78/fix-suportar-quebra-de-linha-na-descricao-do-tema

### DIFF
--- a/src/app/config/theme.tsx
+++ b/src/app/config/theme.tsx
@@ -63,7 +63,7 @@ declare module "@mui/material/styles" {
         display: string;
         flexDirection: string;
         justifyContent: string;
-        padding: number;
+        padding: string;
         boxShadow: string;
         borderRadius: string;
       };
@@ -240,7 +240,7 @@ declare module "@mui/material/styles" {
         display?: string;
         flexDirection?: string;
         justifyContent?: string;
-        padding?: number;
+        padding?: string;
         boxShadow?: string;
         borderRadius?: string;
         margin?: number;
@@ -418,7 +418,7 @@ const theme = createTheme({
     description:{
       display: "flex",
       justifyContent: "space-between",
-      padding: 2,
+      padding: "0px 16px 16px 16px",
       boxShadow: "0em 0em 0.4em rgb(44 44 44 / 40% );",
       borderRadius: "6px",
       margin: 0,

--- a/src/components/Description/DescriptionDivider/index.tsx
+++ b/src/components/Description/DescriptionDivider/index.tsx
@@ -27,7 +27,7 @@ export const DescriptionDivider: React.FC<DescriptionDividerProps> = ({ text }) 
 
   const components = {
     p: (props: React.HTMLAttributes<HTMLHeadingElement>) => (
-      <Typography variant="body1" {...props} />
+      <Typography variant="body1" sx={{ whiteSpace: "pre-wrap", marginTop: 2 }} {...props} />
     ),
     a: (props: React.HTMLAttributes<HTMLAnchorElement>) => (
       <Link
@@ -56,15 +56,15 @@ export const DescriptionDivider: React.FC<DescriptionDividerProps> = ({ text }) 
         <Box sx={{...theme.customStyles.description}}>
           <Box sx={boxStyle}>
             <ReactMarkdown components={components}>
-              {textBox1.replace(/\n\n/g, "")}
+              {textBox1}
             </ReactMarkdown>
           </Box>
 
-          <Divider orientation="vertical" flexItem color="black" sx={{ margin: 0 }} />
+          <Divider orientation="vertical" flexItem color="black" sx={{ marginTop: 2 }} />
 
           <Box sx={boxStyle}>
             <ReactMarkdown components={components}>
-              {textBox2.replace(/\n\n/g, "")}
+              {textBox2}
             </ReactMarkdown>
           </Box>
         </Box>


### PR DESCRIPTION

# <78> - fix-suportar-quebra-de-linha-na-descricao-do-tema

### 🆙 CHANGELOG

- Adicionamos quebra de linha à descrição do tema dividida
- Modificamos os espaçamentos que estavam se sobrepondo

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [x] atualizar a main
- [x] migrar para a branch 78/fix-suportar-quebra-de-linha-na-descricao-do-tema
- [x] Verificar modificações
- [x] Aplicação não deve conter nenhum erro, warning ou console.log
- [x] Alteração proposta no card foi implementada
