### PR TITLE
81/fix padronizar imagens

### DIFF
--- a/src/components/BaseCard/index.tsx
+++ b/src/components/BaseCard/index.tsx
@@ -11,7 +11,7 @@ import { ClickButton } from '../ClickButton';
 interface CardProps{
     title: string;
     description?: string;
-    textImage?: string; 
+    textImage: string; 
     image?: string;
     route: string;
 }
@@ -41,7 +41,12 @@ export const BaseCard: React.FC<CardProps> = ({title, description, textImage, im
                     component="img"
                     image={image}
                     alt={textImage}
-                    sx={theme.customStyles.cardMedia}
+                    sx={{
+                        width: '100%',   
+                        height: 190,  
+                        objectFit: 'cover'
+                    }}
+                    
                 />
             )}
                 <CardContent sx={theme.customStyles.cardContent}> 

--- a/src/components/BaseCard/index.tsx
+++ b/src/components/BaseCard/index.tsx
@@ -43,7 +43,8 @@ export const BaseCard: React.FC<CardProps> = ({title, description, textImage, im
                     alt={textImage}
                     sx={{
                         width: '100%',   
-                        height: 190,  
+                        height: 'auto',  
+                        maxHeight: 210,
                         objectFit: 'cover'
                     }}
                     

--- a/src/components/PageElements/Container/ContainerCardsThemes/index.tsx
+++ b/src/components/PageElements/Container/ContainerCardsThemes/index.tsx
@@ -27,6 +27,7 @@ export const ContainerCardTheme: React.FC<ContainerCardThemeProps> = ({data, cat
                   description={field.cardDescription}
                   route={`${currentPath}/${element.id}-${field.title}`}
                   image={field.image ? field.image[0].url : ""}
+                  textImage={`${field.alt}`}
                 />
               </Grid>
             );

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -29,6 +29,7 @@ export interface ThemeField extends CommonField {
     topics: string;
     category: string;
     topicsDescription: string;
+    alt: string;
 }
 
 export interface TopicField extends CommonField {


### PR DESCRIPTION
#<81> - fix: padronizar as imagens nos cards
====
  
### 🆙 CHANGELOG

- Ver o tamanho correto das imagens no cards;
- Colocar imagens de boa qualidade e de acordo com o tópico;
- Utilizar o atributo alt , colocando a descrição das imagens;

## ⚠️ Me certifico que:

- [x] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [x] Solicitei **code review** para 2 pessoas
- [x] Solicitei **QA** para 2 pessoas
- [x] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [ ] Fazer deploy em ambiente de teste
- [ ] Abrir URL da aplicação de teste - src/components/BaseCard/index.tsx
- [ ] Verificar se as imagens estão de qualidade e tamanho correto
- [ ] Verificar o alt
- [ ] Aplicação não deve conter nenhum erro, warning ou console.log
- [ ] Alteração proposta no card foi implementada