### PR TITLE
96/ fix: melhorar hierarquia de tags de titulo

### DIFF
--- a/src/app/config/theme.tsx
+++ b/src/app/config/theme.tsx
@@ -618,10 +618,33 @@ const theme = createTheme({
       fontWeight: 500,
       letterSpacing: 0.15,
       [`@media (min-width:0px)`]: {
+        fontSize: "1.5rem",
+      },
+      [`@media (min-width:600px)`]: {
+        fontSize: "1.8rem",
+      },
+      [`@media (min-width:900px)`]: {
+        fontSize: "2.2rem",
+      },
+      [`@media (min-width:1200px)`]: {
+        fontSize: "2.4rem",
+      },
+      [`@media (min-width:1536px)`]: {
+        fontSize: "2.4rem",
+      }
+    },
+    h3: {
+      lineHeight: 1.6,
+      fontWeight: 500,
+      letterSpacing: 0.15,
+      [`@media (min-width:0px)`]: {
         fontSize: "1.2rem",
       },
       [`@media (min-width:600px)`]: {
         fontSize: "1.4rem",
+      },
+      [`@media (min-width:900px)`]: {
+        fontSize: "1.5rem",
       },
       [`@media (min-width:1200px)`]: {
         fontSize: "1.6rem",

--- a/src/components/BaseCard/index.tsx
+++ b/src/components/BaseCard/index.tsx
@@ -51,7 +51,7 @@ export const BaseCard: React.FC<CardProps> = ({title, description, textImage, im
                 />
             )}
                 <CardContent sx={theme.customStyles.cardContent}> 
-                    <Typography gutterBottom variant="h2" sx={theme.customStyles.cardTitle}>
+                    <Typography gutterBottom variant="h3" sx={theme.customStyles.cardTitle}>
                         {title}
                     </Typography>
                     <Typography  variant="body1" sx={cardStyles}>

--- a/src/components/ButtonCard/index.tsx
+++ b/src/components/ButtonCard/index.tsx
@@ -31,7 +31,7 @@ export const ButtonCard: React.FC<ButtonCardProps> = ({ title, description, rout
             <Card sx={theme.customStyles.cardButtonContainer}>
                 <CardActionArea onClick={() => handleClick(route)} sx={{height: "100%"}}>
                     <CardContent sx={theme.customStyles.cardButtonContent}>
-                        <Typography gutterBottom variant="h2" sx={theme.customStyles.cardTitle}>
+                        <Typography gutterBottom variant="h3" sx={theme.customStyles.cardTitle}>
                             {title}
                         </Typography>
                         <Typography variant="body1" sx={cardStyles}>

--- a/src/components/CardVideo/index.tsx
+++ b/src/components/CardVideo/index.tsx
@@ -5,7 +5,7 @@ import ReactMarkdown from "react-markdown";
 
 const components = {
   h1: (props: React.HTMLAttributes<HTMLHeadingElement>) => (
-    <Typography variant="h2" {...props} />
+    <Typography variant="caption" {...props} />
   ),
   p: (props: React.HTMLAttributes<HTMLHeadingElement>) => (
     <Typography variant="body1" sx={{ color: theme.palette.textColor?.light }} {...props} />

--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -4,16 +4,17 @@ import Typography from "@mui/material/Typography"
 import { theme, ThemeConfig } from "../../app/config/theme"
 import { Grid } from "@mui/material"
 
-interface TitleProps {
+interface HeadingProps {
     text: string
+      variant: "h1" | "h2" 
 }
 
-export const Title: React.FC<TitleProps> = ({ text }) => {
+export const Heading: React.FC<HeadingProps> = ({ text, variant }) => {
     return (
         <ThemeConfig>
             <Grid container>  
                 <Typography
-                    variant="h1"
+                    variant={variant}
                     sx={theme.customStyles.title}>
                     {text}
                 </Typography>

--- a/src/components/PageElements/Container/ContainerCardsTopics/index.tsx
+++ b/src/components/PageElements/Container/ContainerCardsTopics/index.tsx
@@ -35,8 +35,7 @@ export const ContainerCardTopics: React.FC<ContainerCardTopicsProps> = ({ topics
           <BaseCard
             title={topic}
             description={descriptionsArray[index]}
-            route={`${currentPath}/${infoArray[index]}-${topic}`}
-          />
+            route={`${currentPath}/${infoArray[index]}-${topic}`} textImage={""}          />
         </Grid>
       ))}
     </Grid>

--- a/src/components/PageElements/Content/DetailingExerciseContent/index.tsx
+++ b/src/components/PageElements/Content/DetailingExerciseContent/index.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { Grid} from "@mui/material";
 import { BreadCrumb } from "@/components/BreadCrumb";
-import { Title } from "@/components/title";
 import { ApiResponse, DataItem, ExercisesField } from "@/types/type";
 import { DescriptionFull } from "@/components/Description/DescriptionFull";
 import { AdvanceExercises } from "@/components/AdvanceExercises";
 import { ContainerButtonsExercise } from "../../Container/ContainerButtonsExercise";
+import { Heading } from "@/components/Heading";
 
 interface DetailingContentProps {
   dataTopic:ApiResponse
@@ -39,7 +39,7 @@ const ExerciseContent: React.FC<{
       }}
     >
       <Grid item>
-        <Title text={field.title} />
+        <Heading variant="h1" text={field.title} />
       </Grid>
       <Grid item >
         <AdvanceExercises idExercises={idExercise} data={dataTopic}/>

--- a/src/components/PageElements/Content/DetailingThemeContent/index.tsx
+++ b/src/components/PageElements/Content/DetailingThemeContent/index.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { Grid } from "@mui/material";
 import { BreadCrumb } from "@/components/BreadCrumb";
-import { Title } from "@/components/title";
 import { ContainerCardTopics } from "../../Container/ContainerCardsTopics";
 import { ApiResponse, DataItem, ThemeField } from "@/types/type";
 import { DescriptionDivider } from "../../../Description/DescriptionDivider";
+import { Heading } from "@/components/Heading";
 
 interface DetailingContentProps {
   data: ApiResponse;
@@ -14,11 +14,11 @@ const ThemeContent: React.FC<{ field: ThemeField }> = ({ field }) => (
   <>
     <Grid item xl={12} lg={9} md={6} sm={3}>
       <BreadCrumb />
-      <Title text={field.title} />
+      <Heading variant="h1" text={field.title} />
     </Grid>
     <DescriptionDivider text={field.description} />
     <Grid item xl={12} lg={9} md={6} sm={3}>
-      <Title text={"Tópicos"} />
+      <Heading variant="h2" text={"Tópicos"} />
     </Grid>
     <ContainerCardTopics
       topics={field.topics}

--- a/src/components/PageElements/Content/DetailingTopicContent/index.tsx
+++ b/src/components/PageElements/Content/DetailingTopicContent/index.tsx
@@ -1,11 +1,11 @@
 import React from "react"
 import { Grid } from "@mui/material"
 import { BreadCrumb } from "@/components/BreadCrumb"
-import { Title } from "@/components/title"
 import { ApiResponse, DataItem, TopicField } from "@/types/type"
 import { DescriptionReference } from "@/components/Description/DescriptionReference"
 import { ContainerCardsExercises } from "../../Container/ContainerCardsExercises"
 import { DescriptionWithVideo } from "@/components/Description/DescriptionWithVideo"
+import { Heading } from "@/components/Heading"
 
 interface DetailingContentProps {
   data: ApiResponse
@@ -16,7 +16,7 @@ const TopicContent: React.FC<{ field: TopicField }> = ({ field }) => (
   <>
     <Grid item xl={12} lg={9} md={6} sm={3}>
       <BreadCrumb />
-      <Title text={field.title} />
+      <Heading variant="h1"text={field.title} />
     </Grid>
     <DescriptionWithVideo
       textDescription={field.description}
@@ -26,7 +26,7 @@ const TopicContent: React.FC<{ field: TopicField }> = ({ field }) => (
       references={field.videoReference}
     />
     <Grid item xl={12} lg={9} md={6} sm={3}>
-      <Title text={"Exercícios"} />
+      <Heading variant="h2" text={"Exercícios"} />
     </Grid>
     <ContainerCardsExercises
       exercises={field.exercises}
@@ -37,7 +37,7 @@ const TopicContent: React.FC<{ field: TopicField }> = ({ field }) => (
     {field.references && field.references.trim() != "" && (
       <>
         <Grid item xl={12} lg={9} md={6} sm={3}>
-          <Title text={"Referências"} />
+          <Heading variant="h2" text={"Referências"} />
         </Grid>
         <DescriptionReference text={field.references} />
       </>

--- a/src/components/PageElements/Content/PageThemesContent/index.tsx
+++ b/src/components/PageElements/Content/PageThemesContent/index.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { Grid } from "@mui/material";
-import { Title } from "@/components/title";
 import { ContainerCardTheme } from "../../Container/ContainerCardsThemes";
 import { ApiResponse } from "@/types/type";
+import { Heading } from "@/components/Heading";
 
 interface PageThemesContentProps {
   data: ApiResponse;
@@ -14,7 +14,7 @@ export const PageThemesContent: React.FC<PageThemesContentProps> = ({ data, cate
   return (
     <>
        <Grid item xl={12} lg={9} md={6} sm={3} textAlign={{ xs: 'left', sm: 'center' }}>
-          <Title text={`Bem vindo ao ${category}`} />
+          <Heading variant="h1" text={`Bem vindo ao ${category}`} />
         </Grid>
         <ContainerCardTheme data={data} category={category}/>
     </>


### PR DESCRIPTION
# <96> - fix: melhorar hierarquia de tags de titulo

### 🆙 CHANGELOG

- Fizemos um único componente chamado Heading pra titulos, passando como props a variant h1 ou h2
- Substituimos as tags de Title e SubTitle pela tag Heading
- Adicionamos o theme h3 e modificamos o theme h2

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [ ] dar pull na branch main
- [ ] acessar a branch 96/fix-criacao-de-card-h2-para-melhorar-hierarquia-de-tags
- [ ] rodar o projeto e verificar modificações
- [ ] Aplicação não deve conter nenhum erro, warning ou console.log
- [ ] Alteração proposta no card foi implementada
