### PR TITLE
125/fix colocar componente advance exercises no centro dos botoes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
-        "@mui/icons-material": "^5.15.18",
+        "@mui/icons-material": "^5.16.7",
         "@mui/material": "^5.15.18",
         "@mui/styled-engine-sc": "^6.0.0-alpha.18",
         "husky": "^9.0.11",
@@ -647,9 +647,9 @@
       }
     },
     "node_modules/@mui/icons-material": {
-      "version": "5.15.19",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.15.19.tgz",
-      "integrity": "sha512-RsEiRxA5azN9b8gI7JRqekkgvxQUlitoBOtZglflb8cUDyP12/cP4gRwhb44Ea1/zwwGGjAj66ZJpGHhKfibNA==",
+      "version": "5.16.7",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.16.7.tgz",
+      "integrity": "sha512-UrGwDJCXEszbDI7yV047BYU5A28eGJ79keTCP4cc74WyncuVrnurlmIRxaHL8YK+LI1Kzq+/JM52IAkNnv4u+Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
-    "@mui/icons-material": "^5.15.18",
+    "@mui/icons-material": "^5.16.7",
     "@mui/material": "^5.15.18",
     "@mui/styled-engine-sc": "^6.0.0-alpha.18",
     "husky": "^9.0.11",

--- a/src/app/config/theme.tsx
+++ b/src/app/config/theme.tsx
@@ -214,8 +214,6 @@ declare module "@mui/material/styles" {
       };
       advanceExercises: {
         color: string,
-        background: string,
-        borderRadius: string,
         padding: string,
       };
       cardMediaImage: {
@@ -398,8 +396,6 @@ declare module "@mui/material/styles" {
           };
           advanceExercises?: {
             color?: string,
-            background?: string,
-            borderRadius?: string,
             padding?: string,
           };
           cardMediaImage: {
@@ -582,8 +578,7 @@ const theme = createTheme({
     },
     advanceExercises: {
       color: themePalette.button,
-      background: themePalette.statusInProgress,
-      borderRadius: "10px",
+      padding: "10px 20px",
     },
     cardMediaImage: {
       maxWidth: '100%',

--- a/src/components/ButtonNextExercise/index.tsx
+++ b/src/components/ButtonNextExercise/index.tsx
@@ -1,10 +1,10 @@
-import { theme } from "@/app/config/theme";
-import { Button, ButtonProps, Stack, styled } from "@mui/material";
-import { useRouter, usePathname } from 'next/navigation';
-import { ApiResponse, CommonField, DataItem, TopicField } from "@/types/type";
-import { ClickButton } from "../ClickButton";
-import useMediaQuery from '@mui/material/useMediaQuery';
-import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+import { theme } from "@/app/config/theme"
+import { Button, ButtonProps, Stack, styled } from "@mui/material"
+import { useRouter, usePathname } from 'next/navigation'
+import { ApiResponse, CommonField, DataItem, TopicField } from "@/types/type"
+import { ClickButton } from "../ClickButton"
+import useMediaQuery from '@mui/material/useMediaQuery'
+import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos'
 
 const ButtonFail = styled(Button)<ButtonProps>(() => ({
     "&:hover": {
@@ -12,7 +12,7 @@ const ButtonFail = styled(Button)<ButtonProps>(() => ({
         color: theme.palette.buttonHover?.contrastText,
         border: "none"
     }
-}));
+}))
 
 const ContainerButtonFail = ({ isVisible }: { isVisible: boolean }) => {
     return (
@@ -23,11 +23,6 @@ const ContainerButtonFail = ({ isVisible }: { isVisible: boolean }) => {
                         ...theme.customStyles.button,
                         opacity: isVisible ? 1 : 0,
                         pointerEvents: isVisible ? 'auto' : 'none',
-                        visibility: isVisible ? 'visible' : 'hidden',
-                        display: 'flex',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        transition: 'all 0.3s ease-in-out',
                         [theme.breakpoints.down('md')]: {
                             '.button-text': {
                                 display: 'none',
@@ -42,24 +37,24 @@ const ContainerButtonFail = ({ isVisible }: { isVisible: boolean }) => {
                 </ButtonFail>
             </Stack>
         </aside>
-    );
-};
+    )
+}
 
 
 function isTopicField(field: CommonField): field is TopicField {
-    return field && "exercisesInfo" in field;
+    return field && "exercisesInfo" in field
 }
 
 interface ButtonNextProps {
-    idExercise: string;
-    renderData: ApiResponse;
+    idExercise: string
+    renderData: ApiResponse
 }
 
 export const ButtonNextExercise: React.FC<ButtonNextProps> = ({ idExercise, renderData }) => {
     const router = useRouter()
     const pathname = usePathname()
 
-    const isSmallScreen: boolean = useMediaQuery(theme.breakpoints.down('md'));
+    const isSmallScreen: boolean = useMediaQuery(theme.breakpoints.down('md'))
 
     if (!renderData) {
         return (<ContainerButtonFail isVisible={false} />)
@@ -67,7 +62,7 @@ export const ButtonNextExercise: React.FC<ButtonNextProps> = ({ idExercise, rend
     const partsPathname = pathname.split("/")
     const idExerciseBase = idExercise.split("-")[0]
     const idTopicBase = partsPathname[partsPathname.length - 2]?.split("-")[0]
-    const currentTopic = renderData?.data?.find((element: DataItem) => { return element.field?.rowId === idTopicBase });
+    const currentTopic = renderData?.data?.find((element: DataItem) => { return element.field?.rowId === idTopicBase })
 
     if (currentTopic && isTopicField(currentTopic.field)) {
         const topicField = currentTopic.field
@@ -88,12 +83,12 @@ export const ButtonNextExercise: React.FC<ButtonNextProps> = ({ idExercise, rend
                 isSmallScreen
                     ? <ClickButton click={handleClick} endIcon={<ArrowForwardIosIcon sx={{ fontSize: 15 }} />} />
                     : <ClickButton title="Próximo exercício" click={handleClick} endIcon={<ArrowForwardIosIcon sx={{ fontSize: 15, marginLeft: 1 }} />} />
-            );
+            )
         }
 
-        return <ContainerButtonFail isVisible={false} />;
+        return <ContainerButtonFail isVisible={false} />
     }
 
-    return <ContainerButtonFail isVisible={false} />;
+    return <ContainerButtonFail isVisible={false} />
 
 }

--- a/src/components/ButtonNextExercise/index.tsx
+++ b/src/components/ButtonNextExercise/index.tsx
@@ -1,9 +1,11 @@
 import { theme } from "@/app/config/theme";
 import { Button, ButtonProps, Stack, styled } from "@mui/material";
 import { useRouter, usePathname } from 'next/navigation';
-import useFetchData from "../fetchData";
 import { ApiResponse, CommonField, DataItem, TopicField } from "@/types/type";
 import { ClickButton } from "../ClickButton";
+import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+import useMediaQuery from '@mui/material/useMediaQuery';
+
 
 const ButtonFail = styled(Button)<ButtonProps>(() => ({
     "&:hover": {
@@ -18,6 +20,7 @@ const ContainerButtonFail = () => {
         <aside>
             <Stack spacing={2} direction="row">
                 <ButtonFail sx={theme.customStyles.button} variant="contained">
+                <ArrowForwardIosIcon sx={{ fontSize: 15, marginLeft: 1 }}/>
                     Próximo exercício
                 </ButtonFail>
             </Stack>
@@ -59,9 +62,11 @@ export const ButtonNextExercise: React.FC<ButtonNextProps> = ({ idExercise, rend
             router.push(`${nextExerciseId}-${nextExerciseName}`)
         }
 
+        const isSmallScreen: boolean = useMediaQuery(theme.breakpoints.down('md'));
+
         if (nextExerciseId) {
             return (
-                <ClickButton title="Próximo exercício" click={handleClick} />
+                isSmallScreen ? <ClickButton click={handleClick} endIcon={<ArrowForwardIosIcon sx={{ fontSize: 15 }}/>}/> : <ClickButton title="Próximo exercício" click={handleClick} endIcon={<ArrowForwardIosIcon sx={{ fontSize: 15, marginLeft: 1 }}/>}/>
             )
         }
 

--- a/src/components/ButtonNextExercise/index.tsx
+++ b/src/components/ButtonNextExercise/index.tsx
@@ -3,9 +3,8 @@ import { Button, ButtonProps, Stack, styled } from "@mui/material";
 import { useRouter, usePathname } from 'next/navigation';
 import { ApiResponse, CommonField, DataItem, TopicField } from "@/types/type";
 import { ClickButton } from "../ClickButton";
-import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import useMediaQuery from '@mui/material/useMediaQuery';
-
+import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 
 const ButtonFail = styled(Button)<ButtonProps>(() => ({
     "&:hover": {
@@ -15,33 +14,55 @@ const ButtonFail = styled(Button)<ButtonProps>(() => ({
     }
 }));
 
-const ContainerButtonFail = () => {
+const ContainerButtonFail = ({ isVisible }: { isVisible: boolean }) => {
     return (
         <aside>
             <Stack spacing={2} direction="row">
-                <ButtonFail sx={theme.customStyles.button} variant="contained">
-                <ArrowForwardIosIcon sx={{ fontSize: 15, marginLeft: 1 }}/>
-                    Próximo exercício
+                <ButtonFail
+                    sx={{
+                        ...theme.customStyles.button,
+                        opacity: isVisible ? 1 : 0,
+                        pointerEvents: isVisible ? 'auto' : 'none',
+                        visibility: isVisible ? 'visible' : 'hidden',
+                        display: 'flex',
+                        justifyContent: 'center',
+                        alignItems: 'center',
+                        transition: 'all 0.3s ease-in-out',
+                        [theme.breakpoints.down('md')]: {
+                            '.button-text': {
+                                display: 'none',
+                            },
+                        },
+                    }}
+                >
+                    <span className="button-text" style={{ marginRight: '8px' }}>
+                        Próximo exercício
+                    </span>
+                    <ArrowForwardIosIcon sx={{ fontSize: 15 }} />
                 </ButtonFail>
             </Stack>
         </aside>
-    )
-}
+    );
+};
+
 
 function isTopicField(field: CommonField): field is TopicField {
-    return field && "exercisesInfo" in field;}
+    return field && "exercisesInfo" in field;
+}
 
 interface ButtonNextProps {
     idExercise: string;
     renderData: ApiResponse;
 }
 
-export const ButtonNextExercise: React.FC<ButtonNextProps> = ({ idExercise, renderData  }) => {
+export const ButtonNextExercise: React.FC<ButtonNextProps> = ({ idExercise, renderData }) => {
     const router = useRouter()
     const pathname = usePathname()
 
+    const isSmallScreen: boolean = useMediaQuery(theme.breakpoints.down('md'));
+
     if (!renderData) {
-        return (<ContainerButtonFail />)
+        return (<ContainerButtonFail isVisible={false} />)
     }
     const partsPathname = pathname.split("/")
     const idExerciseBase = idExercise.split("-")[0]
@@ -62,17 +83,17 @@ export const ButtonNextExercise: React.FC<ButtonNextProps> = ({ idExercise, rend
             router.push(`${nextExerciseId}-${nextExerciseName}`)
         }
 
-        const isSmallScreen: boolean = useMediaQuery(theme.breakpoints.down('md'));
-
         if (nextExerciseId) {
             return (
-                isSmallScreen ? <ClickButton click={handleClick} endIcon={<ArrowForwardIosIcon sx={{ fontSize: 15 }}/>}/> : <ClickButton title="Próximo exercício" click={handleClick} endIcon={<ArrowForwardIosIcon sx={{ fontSize: 15, marginLeft: 1 }}/>}/>
-            )
+                isSmallScreen
+                    ? <ClickButton click={handleClick} endIcon={<ArrowForwardIosIcon sx={{ fontSize: 15 }} />} />
+                    : <ClickButton title="Próximo exercício" click={handleClick} endIcon={<ArrowForwardIosIcon sx={{ fontSize: 15, marginLeft: 1 }} />} />
+            );
         }
 
-        return null
+        return <ContainerButtonFail isVisible={false} />;
     }
 
-    return <ContainerButtonFail />
+    return <ContainerButtonFail isVisible={false} />;
 
 }

--- a/src/components/ButtonPreviousExercise/index.tsx
+++ b/src/components/ButtonPreviousExercise/index.tsx
@@ -24,8 +24,8 @@ const ContainerButtonFail = () => {
                 </ButtonFail>
             </Stack>
         </aside>
-    )
-}
+    );
+};
 
 function isTopicField(field: CommonField): field is TopicField {
     return field && "exercisesInfo" in field;
@@ -37,43 +37,44 @@ interface ButtonNextProps {
 }
 
 export const ButtonPreviousExercise: React.FC<ButtonNextProps> = ({ idExercise, renderData }) => {
+    const router = useRouter();
+    const pathname = usePathname();
 
-    const router = useRouter()
-    const pathname = usePathname()
+    const isSmallScreen: boolean = useMediaQuery(theme.breakpoints.down('md'));
 
     if (!renderData) {
-        return (<ContainerButtonFail />)
+        return <ContainerButtonFail />;
     }
-    const partsPathname = pathname.split("/")
-    const idExerciseBase = idExercise.split("-")[0]
-    const idTopicBase = partsPathname[partsPathname.length - 2]?.split("-")[0]
-    const currentTopic = renderData?.data?.find((element: DataItem) => { return element.field?.rowId === idTopicBase });
+
+    const partsPathname = pathname.split("/");
+    const idExerciseBase = idExercise.split("-")[0];
+    const idTopicBase = partsPathname[partsPathname.length - 2]?.split("-")[0];
+    const currentTopic = renderData?.data?.find((element: DataItem) => element.field?.rowId === idTopicBase);
 
     if (currentTopic && isTopicField(currentTopic.field)) {
-        const topicField = currentTopic.field
+        const topicField = currentTopic.field;
 
-        const exerciseIds = topicField.exercisesInfo?.split(",") || []
-        const exerciseNames = topicField.exercises?.split(",") || []
+        const exerciseIds = topicField.exercisesInfo?.split(",") || [];
+        const exerciseNames = topicField.exercises?.split(",") || [];
 
-        const currentExerciseIndex = exerciseIds.indexOf(idExerciseBase)
-        const PreviousExerciseName = exerciseNames[currentExerciseIndex - 1] || null
-        const PreviousExerciseId = exerciseIds[currentExerciseIndex - 1] || null
+        const currentExerciseIndex = exerciseIds.indexOf(idExerciseBase);
+        const PreviousExerciseName = exerciseNames[currentExerciseIndex - 1] || null;
+        const PreviousExerciseId = exerciseIds[currentExerciseIndex - 1] || null;
 
         const handleClick = () => {
-            router.push(`${PreviousExerciseId}-${PreviousExerciseName}`)
-        }
-
-        const isSmallScreen: boolean = useMediaQuery(theme.breakpoints.down('md'));
+            router.push(`${PreviousExerciseId}-${PreviousExerciseName}`);
+        };
 
         if (PreviousExerciseId) {
             return (
-                isSmallScreen ? <ClickButton click={handleClick} backIcon={<ArrowBackIosIcon sx={{ fontSize: 15 }} />} /> : <ClickButton title="Exercício anterior" click={handleClick} backIcon={<ArrowBackIosIcon sx={{ fontSize: 15, marginRight: 1 }} />} />
-            )
+                isSmallScreen
+                    ? <ClickButton click={handleClick} backIcon={<ArrowBackIosIcon sx={{ fontSize: 15 }} />} />
+                    : <ClickButton title="Exercício anterior" click={handleClick} backIcon={<ArrowBackIosIcon sx={{ fontSize: 15, marginRight: 1 }} />} />
+            );
         }
 
-        return null
+        return null;
     }
 
-    return <ContainerButtonFail />
-
-}
+    return <ContainerButtonFail />;
+};

--- a/src/components/ButtonPreviousExercise/index.tsx
+++ b/src/components/ButtonPreviousExercise/index.tsx
@@ -1,9 +1,10 @@
 import { theme } from "@/app/config/theme";
 import { Button, ButtonProps, Stack, styled } from "@mui/material";
 import { useRouter, usePathname } from 'next/navigation';
-import useFetchData from "../fetchData";
 import { ApiResponse, CommonField, DataItem, TopicField } from "@/types/type";
 import { ClickButton } from "../ClickButton";
+import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 const ButtonFail = styled(Button)<ButtonProps>(() => ({
     "&:hover": {
@@ -17,8 +18,9 @@ const ContainerButtonFail = () => {
     return (
         <aside>
             <Stack spacing={2} direction="row">
-                <ButtonFail sx={theme.customStyles.button} variant="contained">
-                   Exercício anterior
+                <ButtonFail sx={theme.customStyles.button} variant="contained" >
+                    <ArrowBackIosIcon sx={{ fontSize: 15, marginRight: 1 }} />
+                    Exercício anterior
                 </ButtonFail>
             </Stack>
         </aside>
@@ -26,7 +28,8 @@ const ContainerButtonFail = () => {
 }
 
 function isTopicField(field: CommonField): field is TopicField {
-    return field && "exercisesInfo" in field;}
+    return field && "exercisesInfo" in field;
+}
 
 interface ButtonNextProps {
     idExercise: string;
@@ -34,7 +37,7 @@ interface ButtonNextProps {
 }
 
 export const ButtonPreviousExercise: React.FC<ButtonNextProps> = ({ idExercise, renderData }) => {
-    
+
     const router = useRouter()
     const pathname = usePathname()
 
@@ -60,9 +63,11 @@ export const ButtonPreviousExercise: React.FC<ButtonNextProps> = ({ idExercise, 
             router.push(`${PreviousExerciseId}-${PreviousExerciseName}`)
         }
 
+        const isSmallScreen: boolean = useMediaQuery(theme.breakpoints.down('md'));
+
         if (PreviousExerciseId) {
             return (
-                <ClickButton title="Exercício anterior" click={handleClick} />
+                isSmallScreen ? <ClickButton click={handleClick} backIcon={<ArrowBackIosIcon sx={{ fontSize: 15 }} />} /> : <ClickButton title="Exercício anterior" click={handleClick} backIcon={<ArrowBackIosIcon sx={{ fontSize: 15, marginRight: 1 }} />} />
             )
         }
 

--- a/src/components/ButtonPreviousExercise/index.tsx
+++ b/src/components/ButtonPreviousExercise/index.tsx
@@ -1,80 +1,107 @@
-import { theme } from "@/app/config/theme";
-import { Button, ButtonProps, Stack, styled } from "@mui/material";
-import { useRouter, usePathname } from 'next/navigation';
-import { ApiResponse, CommonField, DataItem, TopicField } from "@/types/type";
-import { ClickButton } from "../ClickButton";
-import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
-import useMediaQuery from '@mui/material/useMediaQuery';
+import { theme } from "@/app/config/theme"
+import { Button, ButtonProps, Stack, styled } from "@mui/material"
+import { useRouter, usePathname } from "next/navigation"
+import { ApiResponse, CommonField, DataItem, TopicField } from "@/types/type"
+import { ClickButton } from "../ClickButton"
+import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos"
+import useMediaQuery from "@mui/material/useMediaQuery"
 
 const ButtonFail = styled(Button)<ButtonProps>(() => ({
-    "&:hover": {
-        backgroundColor: "gray",
-        color: theme.palette.buttonHover?.contrastText,
-        border: "none"
-    }
-}));
+  "&:hover": {
+    backgroundColor: "gray",
+    color: theme.palette.buttonHover?.contrastText,
+    border: "none",
+  }
+}))
 
-const ContainerButtonFail = () => {
-    return (
-        <aside>
-            <Stack spacing={2} direction="row">
-                <ButtonFail sx={theme.customStyles.button} variant="contained" >
-                    <ArrowBackIosIcon sx={{ fontSize: 15, marginRight: 1 }} />
-                    Exercício anterior
-                </ButtonFail>
-            </Stack>
-        </aside>
-    );
-};
+const ContainerButtonFail = ({ isVisible }: { isVisible: boolean }) => {
+  return (
+    <aside>
+      <Stack spacing={2} direction="row">
+        <ButtonFail
+          sx={{
+            ...theme.customStyles.button,
+            opacity: isVisible ? 1 : 0,
+            pointerEvents: isVisible ? "auto" : "none",
+            [theme.breakpoints.down("md")]: {
+              ".button-text": {
+                display: "none",
+              },
+            },
+          }}
+          variant="contained"
+        >
+          <span className="button-text" style={{ marginRight: "8px" }}>
+            Próximo exercício
+          </span>
+          <ArrowBackIosIcon sx={{ fontSize: 15, marginRight: 1 }} />
+        </ButtonFail>
+      </Stack>
+    </aside>
+  )
+}
 
 function isTopicField(field: CommonField): field is TopicField {
-    return field && "exercisesInfo" in field;
+  return field && "exercisesInfo" in field;
 }
 
 interface ButtonNextProps {
-    idExercise: string;
-    renderData: ApiResponse;
+  idExercise: string
+  renderData: ApiResponse
 }
 
-export const ButtonPreviousExercise: React.FC<ButtonNextProps> = ({ idExercise, renderData }) => {
-    const router = useRouter();
-    const pathname = usePathname();
+export const ButtonPreviousExercise: React.FC<ButtonNextProps> = ({
+  idExercise,
+  renderData,
+}) => {
+  const router = useRouter()
+  const pathname = usePathname()
 
-    const isSmallScreen: boolean = useMediaQuery(theme.breakpoints.down('md'));
+  const isSmallScreen: boolean = useMediaQuery(theme.breakpoints.down("md"))
 
-    if (!renderData) {
-        return <ContainerButtonFail />;
+  if (!renderData) {
+    return <ContainerButtonFail isVisible={false} />
+  }
+
+  const partsPathname = pathname.split("/")
+  const idExerciseBase = idExercise.split("-")[0]
+  const idTopicBase = partsPathname[partsPathname.length - 2]?.split("-")[0]
+  const currentTopic = renderData?.data?.find(
+    (element: DataItem) => element.field?.rowId === idTopicBase
+  )
+
+  if (currentTopic && isTopicField(currentTopic.field)) {
+    const topicField = currentTopic.field
+
+    const exerciseIds = topicField.exercisesInfo?.split(",") || []
+    const exerciseNames = topicField.exercises?.split(",") || []
+
+    const currentExerciseIndex = exerciseIds.indexOf(idExerciseBase)
+    const PreviousExerciseName =
+      exerciseNames[currentExerciseIndex - 1] || null
+    const PreviousExerciseId = exerciseIds[currentExerciseIndex - 1] || null
+
+    const handleClick = () => {
+      router.push(`${PreviousExerciseId}-${PreviousExerciseName}`)
     }
 
-    const partsPathname = pathname.split("/");
-    const idExerciseBase = idExercise.split("-")[0];
-    const idTopicBase = partsPathname[partsPathname.length - 2]?.split("-")[0];
-    const currentTopic = renderData?.data?.find((element: DataItem) => element.field?.rowId === idTopicBase);
-
-    if (currentTopic && isTopicField(currentTopic.field)) {
-        const topicField = currentTopic.field;
-
-        const exerciseIds = topicField.exercisesInfo?.split(",") || [];
-        const exerciseNames = topicField.exercises?.split(",") || [];
-
-        const currentExerciseIndex = exerciseIds.indexOf(idExerciseBase);
-        const PreviousExerciseName = exerciseNames[currentExerciseIndex - 1] || null;
-        const PreviousExerciseId = exerciseIds[currentExerciseIndex - 1] || null;
-
-        const handleClick = () => {
-            router.push(`${PreviousExerciseId}-${PreviousExerciseName}`);
-        };
-
-        if (PreviousExerciseId) {
-            return (
-                isSmallScreen
-                    ? <ClickButton click={handleClick} backIcon={<ArrowBackIosIcon sx={{ fontSize: 15 }} />} />
-                    : <ClickButton title="Exercício anterior" click={handleClick} backIcon={<ArrowBackIosIcon sx={{ fontSize: 15, marginRight: 1 }} />} />
-            );
-        }
-
-        return null;
+    if (PreviousExerciseId) {
+      return isSmallScreen ? (
+        <ClickButton
+          click={handleClick}
+          backIcon={<ArrowBackIosIcon sx={{ fontSize: 15 }} />}
+        />
+      ) : (
+        <ClickButton
+          title="Exercício anterior"
+          click={handleClick}
+          backIcon={<ArrowBackIosIcon sx={{ fontSize: 15, marginRight: 1 }} />}
+        />
+      )
     }
 
-    return <ContainerButtonFail />;
-};
+    return <ContainerButtonFail isVisible={false} />
+  }
+
+  return <ContainerButtonFail isVisible={false} />
+}

--- a/src/components/ClickButton/index.tsx
+++ b/src/components/ClickButton/index.tsx
@@ -3,6 +3,7 @@ import { styled } from "@mui/material/styles"
 import Button, { ButtonProps } from "@mui/material/Button"
 import Stack from "@mui/material/Stack"
 import { theme } from "@/app/config/theme"
+import { ReactNode } from "react"
 
 
 const ColorButton = styled(Button)<ButtonProps>(() => ({    
@@ -14,13 +15,15 @@ const ColorButton = styled(Button)<ButtonProps>(() => ({
 }))
 
 type CardProps = {
-    title: string,
-    click: () => void
+    title?: string,
+    click: () => void,
+    endIcon?: ReactNode,
+    backIcon?: ReactNode
 }
 
-export const ClickButton = ({ title, click }: CardProps) =>
+export const ClickButton = ({ title, click, endIcon, backIcon }: CardProps) =>
     <aside>        
         <Stack spacing={2} direction="row" onClick={click}>
-            <ColorButton sx={theme.customStyles.button} variant="contained">{title}</ColorButton>
+            <ColorButton sx={theme.customStyles.button} variant="contained">{backIcon}{title}{endIcon}</ColorButton>
         </Stack>
     </aside>

--- a/src/components/PageElements/Container/ContainerButtonsExercise/index.tsx
+++ b/src/components/PageElements/Container/ContainerButtonsExercise/index.tsx
@@ -2,6 +2,7 @@ import { ButtonPreviousExercise } from "@/components/ButtonPreviousExercise";
 import { ButtonNextExercise } from "@/components/ButtonNextExercise";
 import { Grid } from "@mui/material";
 import { ApiResponse } from "@/types/type";
+import { AdvanceExercises } from "@/components/AdvanceExercises";
 
 interface ContainerButtonsExerciseProps {
   idExercise: string;
@@ -34,6 +35,9 @@ export const ContainerButtonsExercise: React.FC<
           renderData={data}
           idExercise={idExercise}
         />
+      </Grid>
+        <Grid item >
+        <AdvanceExercises idExercises={idExercise} data={data}/>
       </Grid>
       <Grid item>
         <ButtonNextExercise renderData={data} idExercise={idExercise} />

--- a/src/components/PageElements/Content/DetailingExerciseContent/index.tsx
+++ b/src/components/PageElements/Content/DetailingExerciseContent/index.tsx
@@ -3,7 +3,6 @@ import { Grid} from "@mui/material";
 import { BreadCrumb } from "@/components/BreadCrumb";
 import { ApiResponse, DataItem, ExercisesField } from "@/types/type";
 import { DescriptionFull } from "@/components/Description/DescriptionFull";
-import { AdvanceExercises } from "@/components/AdvanceExercises";
 import { ContainerButtonsExercise } from "../../Container/ContainerButtonsExercise";
 import { Heading } from "@/components/Heading";
 
@@ -41,11 +40,7 @@ const ExerciseContent: React.FC<{
       <Grid item>
         <Heading variant="h1" text={field.title} />
       </Grid>
-      <Grid item >
-        <AdvanceExercises idExercises={idExercise} data={dataTopic}/>
-      </Grid>
     </Grid>
-
     <DescriptionFull text={field.description} />
     <ContainerButtonsExercise idExercise={idExercise} data={dataTopic}/>
   </>


### PR DESCRIPTION
#<125> - fix colocar componente advance exercises no centro dos botoes
====
  
### 🆙 CHANGELOG

- Adicionamos os ícones de (<) e (>);
- Tornamos os botões responsivos;
- Implementamos a lógica dos botões.

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [x] Verificar se a **main** está atualizada
- [x] Vá para a branch -> 125/fix-Colocar-componente-AdvanceExercises-no-centro-dos-botoes
- [x] Verificar se os ícones estão sendo exibidos corretamente
- [x] Verificar se os botões estão responsivos
- [x] Verificar se a paginação esta funcionando corretamente
- [x] Verificar se a lógica está correta e segue os padrões de codificação exigidos
- [ ] Aplicação não deve conter nenhum erro, warning ou console.log
- [ ] Alteração proposta no card foi implementada
