### PR TITLE
118/feat salvar progresso do exercicio no exercicio

### DIFF
--- a/src/app/api/backend/getExerciseStatus/route.ts
+++ b/src/app/api/backend/getExerciseStatus/route.ts
@@ -1,4 +1,5 @@
 import { headers } from 'next/headers';
+import { NextResponse } from 'next/server';
 
 export async function GET(req: Request) {
     const header = headers()
@@ -6,33 +7,37 @@ export async function GET(req: Request) {
     console.log(header.get(`topicId`))
     console.log(header.get(`item`))
 
+ const topicId = header.get(`topicId`)
+ const itemId = header.get(`item`)
+ const accessToken = header.get(`Authorization`)
 
-    // if (!topicId || !itemId) {
-    //   return res.status(400).json({ error: 'topicId and itemId are required' });
-    // }
 
-    // try {
-    //   const baseUrl = process.env.BACKEND_BASE_URL;
-    //   const response = await fetch(`${baseUrl}/topic/${topicId}/item/${itemId}`, {
-    //     method: 'GET',
-    //     headers: {
-    //       'Authorization': `Bearer ${accessToken}`,
-    //       'Content-Type': 'application/json',
-    //     },
-    //   });
+    if (!topicId || !itemId) {
+      return NextResponse.json({ error: 'topicId and itemId are required' },{status:400});
+    }
 
-    //   if (!response.ok) {
-    //     throw new Error(`Error fetching status: ${response.status} - ${response.statusText}`);
-    //   }
+    try {
+      const baseUrl = process.env.BACKEND_BASE_URL;
+      const response = await fetch(`${baseUrl}/topic/${topicId}/item/${itemId}`, {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+      });
 
-    //   const data = await response.json();
-    //   const statusData = data[0].itemStatus;
+      if (!response.ok) {
+        throw new Error(`Error fetching status: ${response.status} - ${response.statusText}`);
+      }
 
-    //   return res.status(200).json({ status: statusData });
+      const data = await response.json();
+      const statusData = data[0].itemStatus;
 
-    // } catch (error) {
-    //   console.error('Error fetching status:', error);
-    //   return res.status(500).json({ error: 'Internal server error' });
+      return NextResponse.json({ status: statusData },{status:200});
 
-    // }
+    } catch (error) {
+      console.error('Error fetching status:', error);
+      return NextResponse.json({ error: 'Internal server error' },{status:500});
+
+    }
 }

--- a/src/app/api/backend/getExerciseStatus/route.ts
+++ b/src/app/api/backend/getExerciseStatus/route.ts
@@ -1,0 +1,38 @@
+import { headers } from 'next/headers';
+
+export async function GET(req: Request) {
+    const header = headers()
+    // console.log(`${params.getExerciseStatus}`)
+    console.log(header.get(`topicId`))
+    console.log(header.get(`item`))
+
+
+    // if (!topicId || !itemId) {
+    //   return res.status(400).json({ error: 'topicId and itemId are required' });
+    // }
+
+    // try {
+    //   const baseUrl = process.env.BACKEND_BASE_URL;
+    //   const response = await fetch(`${baseUrl}/topic/${topicId}/item/${itemId}`, {
+    //     method: 'GET',
+    //     headers: {
+    //       'Authorization': `Bearer ${accessToken}`,
+    //       'Content-Type': 'application/json',
+    //     },
+    //   });
+
+    //   if (!response.ok) {
+    //     throw new Error(`Error fetching status: ${response.status} - ${response.statusText}`);
+    //   }
+
+    //   const data = await response.json();
+    //   const statusData = data[0].itemStatus;
+
+    //   return res.status(200).json({ status: statusData });
+
+    // } catch (error) {
+    //   console.error('Error fetching status:', error);
+    //   return res.status(500).json({ error: 'Internal server error' });
+
+    // }
+}

--- a/src/app/api/backend/updateExerciseStatus/route.ts
+++ b/src/app/api/backend/updateExerciseStatus/route.ts
@@ -1,11 +1,12 @@
 import { headers } from "next/headers"
 import { NextResponse } from "next/server"
 
-export async function GET(req: Request) {
+export async function PUT(req: Request) {
   const header = headers()
 
   const topicId = header.get(`topicId`)
   const itemId = header.get(`itemId`)
+  const itemStatus = header.get(`itemStatus`)
   const accessToken = header.get(`Authorization`)
 
   if (!topicId || !itemId) {
@@ -17,13 +18,17 @@ export async function GET(req: Request) {
 
   try {
     const baseUrl = process.env.BACKEND_BASE_URL
-    const response = await fetch(`${baseUrl}/topic/${topicId}/item/${itemId}`, {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "Content-Type": "application/json",
-      },
-    })
+    const response = await fetch(
+      `${baseUrl}/topic/${topicId}/item/${itemId}/status`,
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ itemStatus: itemStatus }),
+      }
+    )
 
     if (!response.ok) {
       throw new Error(
@@ -32,9 +37,8 @@ export async function GET(req: Request) {
     }
 
     const data = await response.json()
-    const statusData = data[0].itemStatus
+    return NextResponse.json({ data }, { status: 200 })
 
-    return NextResponse.json({ status: statusData }, { status: 200 })
   } catch (error) {
     console.error("Error fetching status:", error)
     return NextResponse.json(

--- a/src/components/StatusSelect/index.tsx
+++ b/src/components/StatusSelect/index.tsx
@@ -32,25 +32,26 @@ export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
   const pathname = usePathname()
 
   const extractIdsFromUrl = (pathname: string): string[] | null => {
-    const parts = pathname.split("/")
-    if (parts.length === 4){
-    const topicId = parts[3].split("-")[0]
-    const itemId = parts[4].split("-")[0]
+    const parts: string[] = pathname.split("/")
 
-    if (topicId && itemId) {
-      const ids = [topicId, itemId]
-      return ids
+    if (parts.length === 5) {
+      const topicId = parts[3].split("-")[0]
+      const itemId = parts[4].split("-")[0]
+
+      if (topicId && itemId) {
+        const ids = [topicId, itemId]
+        return ids
+      }
+
+      return null
     }
-
     return null
-  }
-  return null
   }
 
   const fetchStatus = React.useCallback(async () => {
     if (session) {
       const ids = extractIdsFromUrl(pathname)
-      if (!ids) return
+      if (!ids) return null
 
       setIsLoading(true)
 

--- a/src/components/StatusSelect/index.tsx
+++ b/src/components/StatusSelect/index.tsx
@@ -9,7 +9,7 @@ import { theme } from "@/app/config/theme"
 import { useRouter } from "next/navigation"
 import { useSession } from "next-auth/react"
 import { usePathname } from "next/navigation"
-import {useExerciseStatus} from "@/components/fetchExerciseStatus"
+import { useExerciseStatus } from "@/components/fetchExerciseStatus"
 
 interface StatusSelectProps {
   width?: "30%" | "70%" | "100%"
@@ -19,14 +19,13 @@ export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
   const [status, setStatus] = React.useState<string>("NotStarted")
   const [backgroundColor, setBackgroundColor] =
     React.useState<string>("rgb(225, 225, 225)")
-  const [isLoading, setIsLoading] = React.useState<boolean>(false)
   const router = useRouter()
   // const { data: session } = useSession()
   const session = React.useMemo(() => {
     return {
       user: { email: "teste@gmail.com" },
       accessToken:
-        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InRlc3RlQGdtYWlsLmNvbSIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTczODE3MTQ2NSwiZXhwIjoxNzM4MTc1MDY1fQ.XEtvL6EVm-fYEDTScs3ZGYw52e6LXV7Ix8ebwXL-0qk",
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InRlc3RlQGdtYWlsLmNvbSIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTczODMzMjc0NCwiZXhwIjoxNzM4MzM2MzQ0fQ.yZWsF4eB3xu759CjPeMtR9HLnNkFKdudv2ofr3V5ffc",
     }
   }, [])
 
@@ -49,63 +48,17 @@ export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
     return null
   }
 
-  const ids = extractIdsFromUrl(pathname); 
+  const ids = extractIdsFromUrl(pathname)
 
-  const { status: exerciseStatus, isLoading: statusLoading } = useExerciseStatus({
+  const {
+    status: exerciseStatus,
+    isLoading,
+    updateStatus,
+  } = useExerciseStatus({
     topicId: ids?.[0] || "",
     itemId: ids?.[1] || "",
     accessToken: session?.accessToken || "",
-  });
-
-  const fetchStatus = React.useCallback(async () => {
-    if (session) {
-      try {
-        if (exerciseStatus) {
-          setStatus(exerciseStatus); // Apenas atualiza o estado com o valor do hook
-        }
-      } finally {
-        setIsLoading(false);
-      }
-
-      // try {
-      //   const response = await fetch(`/api/backend/getExerciseStatus`, {
-      //     method: "GET",
-      //     headers: {
-      //       "Content-Type": "application/json",
-      //       Authorization: `${session.accessToken}`,
-      //       topicId: `${ids[0]}`,
-      //       itemId: `${ids[1]}`,
-      //     },
-      //   })
-
-      //   if (!response.ok) {
-      //     console.error(
-      //       `Erro na API: ${response.status} - ${response.statusText}`
-      //     )
-      //     return
-      //   }
-
-      //   const data = await response.json()
-      //   const statusData = data.status
-
-      //   const validStatuses = ["NotStarted", "InProgress", "Completed"]
-      //   if (validStatuses.includes(statusData)) {
-      //     setStatus(statusData)
-      //   } else {
-      //     console.warn(`Status inválido recebido da API: ${statusData}`)
-      //     setStatus("NotStarted")
-      //   }
-      // } catch (error) {
-      //   console.error("Erro ao fazer a requisição GET:", error)
-      // } finally {
-      //   setIsLoading(false)
-      // }
-    }
-  }, [session, ids, exerciseStatus])
-
-  React.useEffect(() => {
-  fetchStatus();
-  }, [fetchStatus]);
+  })
 
   const handleChange = async (event: SelectChangeEvent) => {
     const value = event.target.value as string
@@ -117,35 +70,13 @@ export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
       return
     }
 
-    const ids = extractIdsFromUrl(pathname)
     if (!ids) return
-
-    setIsLoading(true)
-
-    try {
-      const response = await fetch("/api/backend/updateExerciseStatus", {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `${session.accessToken}`,
-          topicId: `${ids[0]}`,
-          itemId: `${ids[1]}`,
-          itemStatus: `${value}`,
-        },
-      })
-
-      if (!response.ok) {
-        console.error(
-          `Erro na API: ${response.status} - ${response.statusText}`
-        )
-        return
-      }
-    } catch (error) {
-      console.error("Erro ao fazer a requisição:", error)
-    } finally {
-      setIsLoading(false)
-    }
+    await updateStatus(value)
   }
+
+  React.useEffect(() => {
+    setStatus(exerciseStatus)
+  }, [exerciseStatus])
 
   React.useEffect(() => {
     switch (status) {

--- a/src/components/StatusSelect/index.tsx
+++ b/src/components/StatusSelect/index.tsx
@@ -8,25 +8,20 @@ import { SelectChangeEvent } from "@mui/material/Select"
 import { theme } from "@/app/config/theme"
 import { useRouter } from "next/navigation"
 import { useSession } from "next-auth/react"
+import { usePathname } from "next/navigation"
 
 interface StatusSelectProps {
   width?: "30%" | "70%" | "100%"
 }
 
 export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
-  // const response: Response = await fetch(url, {
-  //   method: "PUT",
-  //   headers: {
-  //     "Authorization": "Bearer ",
-  //     "Content-Type": "application/json",
-  //   },
-  //   body: JSON.stringify({ status: itemStatus }),
-  // });
+
 
   const [status, setStatus] = React.useState<string>("statusPending")
   const [backgroundColor, setBackgroundColor] = React.useState<string>("rgb(225, 225, 225)")
   const router = useRouter()
   const { data: session } = useSession()
+  const pathname = usePathname()
 
   const handleChange = (event: SelectChangeEvent) => {
     const value = event.target.value as string
@@ -38,6 +33,22 @@ export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
       router.push(`/login?callbackUrl=${currentUrl}`)
     }
   }
+console.log(pathname)
+
+function extractIdsFromUrl(pathname: string): { topicId: string; itemId: string } | null {
+  // Quebra a URL em partes separadas por "/"
+  const parts = pathname.split('/');
+  console.log(parts[4])
+  console.log(parts[5])
+  
+
+  // Retorna null se não for possível extrair os IDs
+  return null;
+}
+extractIdsFromUrl(pathname)
+  // try{ 
+  //   const response = await fetch(`${apiURL}/api/topic/${detailingTopic}/item/${detailingExercise}/status`)
+  // }
 
 
   React.useEffect(() => {

--- a/src/components/StatusSelect/index.tsx
+++ b/src/components/StatusSelect/index.tsx
@@ -43,47 +43,7 @@ export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
 
     return null
   }
-
-  // const fetchStatus = React.useCallback(async () => {
-  //   if (session) {
-  //     const ids = extractIdsFromUrl(pathname)
-  //     if (!ids) return
-
-  //     try {
-  //       const baseUrl = process.env.NEXT_PUBLIC_BACKEND_BASE_URL
-  //       const response = await fetch(
-  //         `${baseUrl}/topic/${ids[0]}/item/${ids[1]}`,
-  //         {
-  //           method: "GET",
-  //           headers: {
-  //             Authorization: `Bearer ${session.accessToken}`,
-  //           },
-  //         }
-  //       )
-
-  //       if (!response.ok) {
-  //         console.error(
-  //           `Erro na API: ${response.status} - ${response.statusText}`
-  //         )
-  //         return
-  //       }
-
-  //       const data = await response.json()
-  //       const statusData = data[0].itemStatus
-
-  //       const validStatuses = ["NotStarted", "InProgress", "Completed"]
-  //       if (validStatuses.includes(statusData)) {
-  //         setStatus(statusData)
-  //       } else {
-  //         console.warn(`Status inválido recebido da API: ${data.itemStatus}`)
-  //         setStatus("NotStarted")
-  //       }
-  //     } catch (error) {
-  //       console.error("Erro ao fazer a requisição GET:", error)
-  //     }
-  //   }
-  // }, [session, pathname])
-
+  
   const fetchStatus = React.useCallback(async () => {
     if (session) {
       const ids = extractIdsFromUrl(pathname);

--- a/src/components/StatusSelect/index.tsx
+++ b/src/components/StatusSelect/index.tsx
@@ -25,7 +25,7 @@ export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
     return {
       user: { email: "teste@gmail.com" },
       accessToken:
-        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InRlc3RlQGdtYWlsLmNvbSIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTczODMzMjc0NCwiZXhwIjoxNzM4MzM2MzQ0fQ.yZWsF4eB3xu759CjPeMtR9HLnNkFKdudv2ofr3V5ffc",
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InRlc3RlQGdtYWlsLmNvbSIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTczODM0MjM1NSwiZXhwIjoxNzM4MzQ1OTU1fQ._4v0n-ldNwhwIQ8rpqbtRsrDbPEnZSFC4wtLpYpj2_g",
     }
   }, [])
 

--- a/src/components/StatusSelect/index.tsx
+++ b/src/components/StatusSelect/index.tsx
@@ -1,96 +1,104 @@
-import * as React from "react";
-import Box from "@mui/material/Box";
-import InputLabel from "@mui/material/InputLabel";
-import MenuItem from "@mui/material/MenuItem";
-import FormControl from "@mui/material/FormControl";
-import Select from "@mui/material/Select";
-import { SelectChangeEvent } from "@mui/material/Select";
-import { theme } from "@/app/config/theme";
-import { useRouter } from "next/navigation";
-import { useSession } from "next-auth/react";
-import { usePathname } from "next/navigation";
+import * as React from "react"
+import Box from "@mui/material/Box"
+import InputLabel from "@mui/material/InputLabel"
+import MenuItem from "@mui/material/MenuItem"
+import FormControl from "@mui/material/FormControl"
+import Select from "@mui/material/Select"
+import { SelectChangeEvent } from "@mui/material/Select"
+import { theme } from "@/app/config/theme"
+import { useRouter } from "next/navigation"
+import { useSession } from "next-auth/react"
+import { usePathname } from "next/navigation"
 
 interface StatusSelectProps {
-  width?: "30%" | "70%" | "100%";
+  width?: "30%" | "70%" | "100%"
 }
 
 export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
-  const [status, setStatus] = React.useState<string>("statusPending");
+  const [status, setStatus] = React.useState<string>("NotStarted")
   const [backgroundColor, setBackgroundColor] =
-    React.useState<string>("rgb(225, 225, 225)");
-  const [isLoading, setIsLoading] = React.useState<boolean>(false);
-  const router = useRouter();
-  //const { data: session } = useSession();
-  const session = { user: { email: "teste@gmail.com" }, accessToken: "yJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InRlc3RlQGdtYWlsLmNvbSIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTczNzYzNzM0OSwiZXhwIjoxNzM3NjQwOTQ5fQ.7VPT0cgN_sIOUJNunNR4kcgAMLWoJL9PuzyDtUVkEM0" };
+    React.useState<string>("rgb(225, 225, 225)")
+  const [isLoading, setIsLoading] = React.useState<boolean>(false)
+  const router = useRouter()
+  //const { data: session } = useSession()
+  const session = {
+    user: { email: "teste@gmail.com" },
+    accessToken:
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InRlc3RlQGdtYWlsLmNvbSIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTczNzY1NDQ2OSwiZXhwIjoxNzM3NjU4MDY5fQ.AoqzN34ud6b6dbTdLAAm7D71f4o5Uu9DPX_JGcGTqPI",
+  }
 
-  const pathname = usePathname();
-
+  const pathname = usePathname()
+  
   const extractIdsFromUrl = (pathname: string): string[] | null => {
-    const parts = pathname.split("/");
-    const topicId = parts[3];
-    const itemId = parts[4];
+    const parts = pathname.split("/")
+    const topicId = parts[3].split("-")[0]
+    const itemId = parts[4].split("-")[0]
 
     if (topicId && itemId) {
-      const ids = [topicId, itemId];
-      return ids;
+      const ids = [topicId, itemId]
+      return ids
     }
 
-    return null;
-  };
+    return null
+  }
 
   const handleChange = async (event: SelectChangeEvent) => {
-    const value = event.target.value as string;
-    setStatus(value);
-  
+    const value = event.target.value as string
+    setStatus(value)
+
     if (!session) {
-      const currentUrl = encodeURIComponent(window.location.href);
-      router.push(`/login?callbackUrl=${currentUrl}`);
-      return;
+      const currentUrl = encodeURIComponent(window.location.href)
+      router.push(`/login?callbackUrl=${currentUrl}`)
+      return
     }
-  
-    const ids = extractIdsFromUrl(pathname);
-    if (!ids) return;
-  
-    setIsLoading(true);
-  
+
+    const ids = extractIdsFromUrl(pathname)
+    if (!ids) return
+
+    setIsLoading(true)
+
     try {
+      const baseUrl = process.env.NEXT_PUBLIC_BACKEND_BASE_URL
+     
       const response = await fetch(
-        `http://localhost:5002/topic/${ids[0]}/item/${ids[1]}/status`,
+        `${baseUrl}/topic/${ids[0]}/item/${ids[1]}/status`,
         {
           method: "PUT",
           headers: {
+            Authorization: `Bearer ${session.accessToken}`,
             "Content-Type": "application/json",
-            Authorization: `Bearer ${session.accessToken}`
           },
-          body: JSON.stringify({ status: value }),
+          body: JSON.stringify({ itemStatus: value }),
         }
-      );
-  
+      )
+
       if (!response.ok) {
-        console.error(`Erro na API: ${response.status} - ${response.statusText}`);
+        console.error(
+          `Erro na API: ${response.status} - ${response.statusText}`
+        )
       }
     } catch (error) {
-      console.error("Erro ao fazer a requisição:", error);
+      console.error("Erro ao fazer a requisição:", error)
     } finally {
-      setIsLoading(false); 
+      setIsLoading(false)
     }
-  };
-  
+  }
+
   React.useEffect(() => {
     switch (status) {
-      case "statusConcluded":
-        setBackgroundColor(theme.palette.statusSelect?.light || "");
-        break;
-      case "statusInProgress":
-        setBackgroundColor(theme.palette.statusSelect?.dark || "");
-        break;
-      case "statusPending":
-        setBackgroundColor(theme.palette.statusSelect?.main || "");
-        break;
+      case "Completed":
+        setBackgroundColor(theme.palette.statusSelect?.light || "")
+        break
+      case "InProgress":
+        setBackgroundColor(theme.palette.statusSelect?.dark || "")
+        break
+      case "NotStarted":
+        setBackgroundColor(theme.palette.statusSelect?.main || "")
+        break
       default:
-        setBackgroundColor("rgb(225, 225, 225)");
+        setBackgroundColor("rgb(225, 225, 225)")
     }
-  }, [status]);
+  }, [status])
 
   return (
     <Box
@@ -134,11 +142,11 @@ export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
             height: "40px",
           }}
         >
-          <MenuItem value="statusPending">Não Iniciado</MenuItem>
-          <MenuItem value="statusInProgress">Em Andamento</MenuItem>
-          <MenuItem value="statusConcluded">Concluído</MenuItem>
+          <MenuItem value="NotStarted">Não Iniciado</MenuItem>
+          <MenuItem value="InProgress">Em Andamento</MenuItem>
+          <MenuItem value="Completed">Concluído</MenuItem>
         </Select>
       </FormControl>
     </Box>
-  );
+  )
 }

--- a/src/components/StatusSelect/index.tsx
+++ b/src/components/StatusSelect/index.tsx
@@ -42,6 +42,45 @@ export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
     return null
   }
 
+  const fetchStatus = async () => {
+    if (!session) {
+      const currentUrl = encodeURIComponent(window.location.href);
+      router.push(`/login?callbackUrl=${currentUrl}`);
+      return;
+    }
+  
+    const ids = extractIdsFromUrl(pathname);
+    if (!ids) return;
+  
+    try {
+      const baseUrl = process.env.NEXT_PUBLIC_BACKEND_BASE_URL;
+      const response = await fetch(
+        `${baseUrl}/topic/${ids[0]}/item/${ids[1]}`,
+        {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${session.accessToken}`,
+          },
+        }
+      );
+  
+      if (!response.ok) {
+        console.error(`Erro na API: ${response.status} - ${response.statusText}`);
+        return;
+      }
+  
+      const data = await response.json();
+      setStatus(data.itemStatus); // Atualiza o estado com o status recebido
+    } catch (error) {
+      console.error("Erro ao fazer a requisição GET:", error);
+    }
+  };
+  
+  React.useEffect(() => {
+    fetchStatus(); // Chama a função para buscar o status ao montar o componente
+  }, []);
+  
+
   const handleChange = async (event: SelectChangeEvent) => {
     const value = event.target.value as string
     setStatus(value)

--- a/src/components/StatusSelect/index.tsx
+++ b/src/components/StatusSelect/index.tsx
@@ -20,15 +20,17 @@ export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
     React.useState<string>("rgb(225, 225, 225)")
   const [isLoading, setIsLoading] = React.useState<boolean>(false)
   const router = useRouter()
-  //const { data: session } = useSession()
-  const session = {
-    user: { email: "teste@gmail.com" },
-    accessToken:
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InRlc3RlQGdtYWlsLmNvbSIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTczNzY1NDQ2OSwiZXhwIjoxNzM3NjU4MDY5fQ.AoqzN34ud6b6dbTdLAAm7D71f4o5Uu9DPX_JGcGTqPI",
-  }
+  // const { data: session } = useSession()
+  const session = React.useMemo(() => {
+    return {
+      user: { email: "teste@gmail.com" },
+      accessToken:
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InRlc3RlQGdtYWlsLmNvbSIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTczODAwMDIzMiwiZXhwIjoxNzM4MDAzODMyfQ.Kf9-1Vc4z50hvnwF1pjd18AN8CHklivmqa_wzCf6CuI",
+    }
+  }, [])
 
   const pathname = usePathname()
-  
+
   const extractIdsFromUrl = (pathname: string): string[] | null => {
     const parts = pathname.split("/")
     const topicId = parts[3].split("-")[0]
@@ -42,44 +44,49 @@ export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
     return null
   }
 
-  const fetchStatus = async () => {
-    if (!session) {
-      const currentUrl = encodeURIComponent(window.location.href);
-      router.push(`/login?callbackUrl=${currentUrl}`);
-      return;
-    }
-  
-    const ids = extractIdsFromUrl(pathname);
-    if (!ids) return;
-  
-    try {
-      const baseUrl = process.env.NEXT_PUBLIC_BACKEND_BASE_URL;
-      const response = await fetch(
-        `${baseUrl}/topic/${ids[0]}/item/${ids[1]}`,
-        {
-          method: "GET",
-          headers: {
-            Authorization: `Bearer ${session.accessToken}`,
-          },
+  const fetchStatus = React.useCallback(async () => {
+    if (session) {
+      const ids = extractIdsFromUrl(pathname)
+      if (!ids) return
+
+      try {
+        const baseUrl = process.env.NEXT_PUBLIC_BACKEND_BASE_URL
+        const response = await fetch(
+          `${baseUrl}/topic/${ids[0]}/item/${ids[1]}`,
+          {
+            method: "GET",
+            headers: {
+              Authorization: `Bearer ${session.accessToken}`,
+            },
+          }
+        )
+
+        if (!response.ok) {
+          console.error(
+            `Erro na API: ${response.status} - ${response.statusText}`
+          )
+          return
         }
-      );
-  
-      if (!response.ok) {
-        console.error(`Erro na API: ${response.status} - ${response.statusText}`);
-        return;
+
+        const data = await response.json()
+        const statusData = data[0].itemStatus
+
+        const validStatuses = ["NotStarted", "InProgress", "Completed"]
+        if (validStatuses.includes(statusData)) {
+          setStatus(statusData)
+        } else {
+          console.warn(`Status inválido recebido da API: ${data.itemStatus}`)
+          setStatus("NotStarted")
+        }
+      } catch (error) {
+        console.error("Erro ao fazer a requisição GET:", error)
       }
-  
-      const data = await response.json();
-      setStatus(data.itemStatus); // Atualiza o estado com o status recebido
-    } catch (error) {
-      console.error("Erro ao fazer a requisição GET:", error);
     }
-  };
-  
+  }, [session, pathname])
+
   React.useEffect(() => {
-    fetchStatus(); // Chama a função para buscar o status ao montar o componente
-  }, []);
-  
+    fetchStatus()
+  }, [fetchStatus])
 
   const handleChange = async (event: SelectChangeEvent) => {
     const value = event.target.value as string
@@ -98,7 +105,7 @@ export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
 
     try {
       const baseUrl = process.env.NEXT_PUBLIC_BACKEND_BASE_URL
-     
+
       const response = await fetch(
         `${baseUrl}/topic/${ids[0]}/item/${ids[1]}/status`,
         {
@@ -167,7 +174,7 @@ export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
           notched={true}
           labelId="statusLeveling"
           id="statusSelect"
-          value={status}
+          value={status || "NotStarted"}
           label="Status"
           onChange={handleChange}
           disabled={isLoading}

--- a/src/components/StatusSelect/index.tsx
+++ b/src/components/StatusSelect/index.tsx
@@ -14,6 +14,15 @@ interface StatusSelectProps {
 }
 
 export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
+  // const response: Response = await fetch(url, {
+  //   method: "PUT",
+  //   headers: {
+  //     "Authorization": "Bearer ",
+  //     "Content-Type": "application/json",
+  //   },
+  //   body: JSON.stringify({ status: itemStatus }),
+  // });
+
   const [status, setStatus] = React.useState<string>("statusPending")
   const [backgroundColor, setBackgroundColor] = React.useState<string>("rgb(225, 225, 225)")
   const router = useRouter()

--- a/src/components/StatusSelect/index.tsx
+++ b/src/components/StatusSelect/index.tsx
@@ -25,7 +25,7 @@ export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
     return {
       user: { email: "teste@gmail.com" },
       accessToken:
-        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InRlc3RlQGdtYWlsLmNvbSIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTczODA4NjU1OCwiZXhwIjoxNzM4MDkwMTU4fQ.5eXYvy1xlquid4J964kXzXNoD93OC8ei-yREmz39rTc",
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InRlc3RlQGdtYWlsLmNvbSIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTczODE3MTQ2NSwiZXhwIjoxNzM4MTc1MDY1fQ.XEtvL6EVm-fYEDTScs3ZGYw52e6LXV7Ix8ebwXL-0qk",
     }
   }, [])
 
@@ -43,51 +43,49 @@ export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
 
     return null
   }
-  
+
   const fetchStatus = React.useCallback(async () => {
     if (session) {
-      const ids = extractIdsFromUrl(pathname);
-      if (!ids) return;
-      
-  
-      setIsLoading(true);
-  
+      const ids = extractIdsFromUrl(pathname)
+      if (!ids) return
+
+      setIsLoading(true)
+
       try {
-        const response = await fetch(
-          `/api/backend/getExerciseStatus`,
-          {
-            method: 'GET',
-            headers: {
-              'Content-Type': 'application/json',
-              "Authorization": `${session.accessToken}`,
-              "topicId": `${ids[0]}`,
-              "item": `${ids[1]}`
-            },
-          }
-        );
-  
+        const response = await fetch(`/api/backend/getExerciseStatus`, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `${session.accessToken}`,
+            topicId: `${ids[0]}`,
+            itemId: `${ids[1]}`,
+          },
+        })
+
         if (!response.ok) {
-          console.error(`Erro na API: ${response.status} - ${response.statusText}`);
-          return;
+          console.error(
+            `Erro na API: ${response.status} - ${response.statusText}`
+          )
+          return
         }
-  
-        const data = await response.json();
-        const statusData = data.status;
-  
-        const validStatuses = ["NotStarted", "InProgress", "Completed"];
+
+        const data = await response.json()
+        const statusData = data.status
+
+        const validStatuses = ["NotStarted", "InProgress", "Completed"]
         if (validStatuses.includes(statusData)) {
-          setStatus(statusData);
+          setStatus(statusData)
         } else {
-          console.warn(`Status inválido recebido da API: ${statusData}`);
-          setStatus("NotStarted");
+          console.warn(`Status inválido recebido da API: ${statusData}`)
+          setStatus("NotStarted")
         }
       } catch (error) {
-        console.error("Erro ao fazer a requisição GET:", error);
+        console.error("Erro ao fazer a requisição GET:", error)
       } finally {
-        setIsLoading(false);
+        setIsLoading(false)
       }
     }
-  }, [session, pathname]);
+  }, [session, pathname])
 
   React.useEffect(() => {
     fetchStatus()
@@ -109,24 +107,22 @@ export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
     setIsLoading(true)
 
     try {
-      const baseUrl = process.env.NEXT_PUBLIC_BACKEND_BASE_URL
-
-      const response = await fetch(
-        `${baseUrl}/topic/${ids[0]}/item/${ids[1]}/status`,
-        {
-          method: "PUT",
-          headers: {
-            Authorization: `Bearer ${session.accessToken}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ itemStatus: value }),
-        }
-      )
+      const response = await fetch("/api/backend/updateExerciseStatus", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `${session.accessToken}`,
+          topicId: `${ids[0]}`,
+          itemId: `${ids[1]}`,
+          itemStatus: `${value}`,
+        },
+      })
 
       if (!response.ok) {
         console.error(
           `Erro na API: ${response.status} - ${response.statusText}`
         )
+        return
       }
     } catch (error) {
       console.error("Erro ao fazer a requisição:", error)

--- a/src/components/StatusSelect/index.tsx
+++ b/src/components/StatusSelect/index.tsx
@@ -33,6 +33,7 @@ export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
 
   const extractIdsFromUrl = (pathname: string): string[] | null => {
     const parts = pathname.split("/")
+    if (parts.length === 4){
     const topicId = parts[3].split("-")[0]
     const itemId = parts[4].split("-")[0]
 
@@ -42,6 +43,8 @@ export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
     }
 
     return null
+  }
+  return null
   }
 
   const fetchStatus = React.useCallback(async () => {

--- a/src/components/StatusSelect/index.tsx
+++ b/src/components/StatusSelect/index.tsx
@@ -25,7 +25,7 @@ export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
     return {
       user: { email: "teste@gmail.com" },
       accessToken:
-        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InRlc3RlQGdtYWlsLmNvbSIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTczODAwMDIzMiwiZXhwIjoxNzM4MDAzODMyfQ.Kf9-1Vc4z50hvnwF1pjd18AN8CHklivmqa_wzCf6CuI",
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InRlc3RlQGdtYWlsLmNvbSIsIm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTczODA4NjU1OCwiZXhwIjoxNzM4MDkwMTU4fQ.5eXYvy1xlquid4J964kXzXNoD93OC8ei-yREmz39rTc",
     }
   }, [])
 
@@ -44,45 +44,90 @@ export default function StatusSelect({ width = "30%" }: StatusSelectProps) {
     return null
   }
 
+  // const fetchStatus = React.useCallback(async () => {
+  //   if (session) {
+  //     const ids = extractIdsFromUrl(pathname)
+  //     if (!ids) return
+
+  //     try {
+  //       const baseUrl = process.env.NEXT_PUBLIC_BACKEND_BASE_URL
+  //       const response = await fetch(
+  //         `${baseUrl}/topic/${ids[0]}/item/${ids[1]}`,
+  //         {
+  //           method: "GET",
+  //           headers: {
+  //             Authorization: `Bearer ${session.accessToken}`,
+  //           },
+  //         }
+  //       )
+
+  //       if (!response.ok) {
+  //         console.error(
+  //           `Erro na API: ${response.status} - ${response.statusText}`
+  //         )
+  //         return
+  //       }
+
+  //       const data = await response.json()
+  //       const statusData = data[0].itemStatus
+
+  //       const validStatuses = ["NotStarted", "InProgress", "Completed"]
+  //       if (validStatuses.includes(statusData)) {
+  //         setStatus(statusData)
+  //       } else {
+  //         console.warn(`Status inválido recebido da API: ${data.itemStatus}`)
+  //         setStatus("NotStarted")
+  //       }
+  //     } catch (error) {
+  //       console.error("Erro ao fazer a requisição GET:", error)
+  //     }
+  //   }
+  // }, [session, pathname])
+
   const fetchStatus = React.useCallback(async () => {
     if (session) {
-      const ids = extractIdsFromUrl(pathname)
-      if (!ids) return
-
+      const ids = extractIdsFromUrl(pathname);
+      if (!ids) return;
+      
+  
+      setIsLoading(true);
+  
       try {
-        const baseUrl = process.env.NEXT_PUBLIC_BACKEND_BASE_URL
         const response = await fetch(
-          `${baseUrl}/topic/${ids[0]}/item/${ids[1]}`,
+          `/api/backend/getExerciseStatus`,
           {
-            method: "GET",
+            method: 'GET',
             headers: {
-              Authorization: `Bearer ${session.accessToken}`,
+              'Content-Type': 'application/json',
+              "Authorization": `${session.accessToken}`,
+              "topicId": `${ids[0]}`,
+              "item": `${ids[1]}`
             },
           }
-        )
-
+        );
+  
         if (!response.ok) {
-          console.error(
-            `Erro na API: ${response.status} - ${response.statusText}`
-          )
-          return
+          console.error(`Erro na API: ${response.status} - ${response.statusText}`);
+          return;
         }
-
-        const data = await response.json()
-        const statusData = data[0].itemStatus
-
-        const validStatuses = ["NotStarted", "InProgress", "Completed"]
+  
+        const data = await response.json();
+        const statusData = data.status;
+  
+        const validStatuses = ["NotStarted", "InProgress", "Completed"];
         if (validStatuses.includes(statusData)) {
-          setStatus(statusData)
+          setStatus(statusData);
         } else {
-          console.warn(`Status inválido recebido da API: ${data.itemStatus}`)
-          setStatus("NotStarted")
+          console.warn(`Status inválido recebido da API: ${statusData}`);
+          setStatus("NotStarted");
         }
       } catch (error) {
-        console.error("Erro ao fazer a requisição GET:", error)
+        console.error("Erro ao fazer a requisição GET:", error);
+      } finally {
+        setIsLoading(false);
       }
     }
-  }, [session, pathname])
+  }, [session, pathname]);
 
   React.useEffect(() => {
     fetchStatus()

--- a/src/components/fetchExerciseStatus/index.ts
+++ b/src/components/fetchExerciseStatus/index.ts
@@ -1,17 +1,17 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react"
 
 interface UseExerciseStatusProps {
-  topicId: string;
-  itemId: string;
-  accessToken: string;
+  topicId: string
+  itemId: string
+  accessToken: string
 }
 
 export const useExerciseStatus = ({ topicId, itemId, accessToken }: UseExerciseStatusProps) => {
-  const [status, setStatus] = useState<string>("NotStarted");
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [status, setStatus] = useState<string>("NotStarted")
+  const [isLoading, setIsLoading] = useState<boolean>(false)
 
   const fetchStatus = useCallback(async () => {
-    setIsLoading(true);
+    setIsLoading(true)
     try {
       const response = await fetch(`/api/backend/getExerciseStatus`, {
         method: "GET",
@@ -21,24 +21,25 @@ export const useExerciseStatus = ({ topicId, itemId, accessToken }: UseExerciseS
           topicId,
           itemId,
         },
-      });
+      })
 
-      if (!response.ok) throw new Error(`Erro ${response.status}`);
+      if (!response.ok) throw new Error(`Erro ${response.status}`)
 
-      const data = await response.json();
-      const validStatuses = ["NotStarted", "InProgress", "Completed"];
+      const data = await response.json()
+      const validStatuses = ["NotStarted", "InProgress", "Completed"]
 
-      setStatus(validStatuses.includes(data.status) ? data.status : "NotStarted");
+      setStatus(validStatuses.includes(data.status) ? data.status : "NotStarted")
     } catch (error) {
-      console.error("Erro ao buscar status:", error);
+      console.error("Erro ao buscar status:", error)
     } finally {
-      setIsLoading(false);
+      setIsLoading(false)
     }
-  }, [topicId, itemId, accessToken]);
+  }, [topicId, itemId, accessToken])
 
   const updateStatus = async (newStatus: string) => {
-    setStatus(newStatus);
-    setIsLoading(true);
+    setIsLoading(true)
+    setStatus(newStatus)
+    
     try {
       const response = await fetch("/api/backend/updateExerciseStatus", {
         method: "PUT",
@@ -49,19 +50,19 @@ export const useExerciseStatus = ({ topicId, itemId, accessToken }: UseExerciseS
           itemId,
           itemStatus: newStatus,
         },
-      });
+      })
 
-      if (!response.ok) throw new Error(`Erro ${response.status}`);
+      if (!response.ok) throw new Error(`Erro ${response.status}`)
     } catch (error) {
-      console.error("Erro ao atualizar status:", error);
+      console.error("Erro ao atualizar status:", error)
     } finally {
-      setIsLoading(false);
+      setIsLoading(false)
     }
-  };
+  }
 
   useEffect(() => {
-    fetchStatus();
-  }, [fetchStatus]);
+    fetchStatus()
+  }, [fetchStatus])
 
-  return { status, isLoading, updateStatus };
-};
+  return { status, isLoading, updateStatus }
+}

--- a/src/components/fetchExerciseStatus/index.ts
+++ b/src/components/fetchExerciseStatus/index.ts
@@ -11,6 +11,7 @@ export const useExerciseStatus = ({ topicId, itemId, accessToken }: UseExerciseS
   const [isLoading, setIsLoading] = useState<boolean>(false)
 
   const fetchStatus = useCallback(async () => {
+    if (!topicId || !itemId || !accessToken) return;
     setIsLoading(true)
     try {
       const response = await fetch(`/api/backend/getExerciseStatus`, {

--- a/src/components/fetchExerciseStatus/index.ts
+++ b/src/components/fetchExerciseStatus/index.ts
@@ -1,0 +1,67 @@
+import { useState, useEffect, useCallback } from "react";
+
+interface UseExerciseStatusProps {
+  topicId: string;
+  itemId: string;
+  accessToken: string;
+}
+
+export const useExerciseStatus = ({ topicId, itemId, accessToken }: UseExerciseStatusProps) => {
+  const [status, setStatus] = useState<string>("NotStarted");
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const fetchStatus = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await fetch(`/api/backend/getExerciseStatus`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `${accessToken}`,
+          topicId,
+          itemId,
+        },
+      });
+
+      if (!response.ok) throw new Error(`Erro ${response.status}`);
+
+      const data = await response.json();
+      const validStatuses = ["NotStarted", "InProgress", "Completed"];
+
+      setStatus(validStatuses.includes(data.status) ? data.status : "NotStarted");
+    } catch (error) {
+      console.error("Erro ao buscar status:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [topicId, itemId, accessToken]);
+
+  const updateStatus = async (newStatus: string) => {
+    setStatus(newStatus);
+    setIsLoading(true);
+    try {
+      const response = await fetch("/api/backend/updateExerciseStatus", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `${accessToken}`,
+          topicId,
+          itemId,
+          itemStatus: newStatus,
+        },
+      });
+
+      if (!response.ok) throw new Error(`Erro ${response.status}`);
+    } catch (error) {
+      console.error("Erro ao atualizar status:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  return { status, isLoading, updateStatus };
+};


### PR DESCRIPTION
#<118> - feat salvar progresso do exercício no exercício
  
### 🆙 CHANGELOG

- Criamos Função para extrair Ids da pagina, para fazer requisições com itemId e topicId.
- Criamos duas requisições para o back end em uma pasta na Api > backend, uma recupera o status que está armazenado no 
banco de dados e a outra atualiza.
- Dentro do componente statusSelect, criamos um hook do React para uma requisição intermediaria.


## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar: Parte 1 Back end

- [ ] Abrir back end e garantir que a main está atualizada.
- [ ] Ir para a branch 118
- [ ] Rodar com npm run dev
- [ ] Gerar um token npx ts-node src/script/jwtGenerator.ts que vai ser utilizado no front end.
- [ ] Abrir dbeaver e adicionar no itemId rw17169056027059821dc e no topicId rw1721236357157ccf465 referenciando no usuário um.

## ⚠️ Como testar: Parte 2 Front end

- [ ] ] Abrir front end e garantir que a main está atualizada.
- [ ] Ir para a branch 118
- [ ] Rodar com npm run dev
- [ ] Ir no componente statusSelect e colocar no accessToken, o token gerado no back end.
- [ ] Pedir para Geovana ou stephany a chave. env do back end.
- [ ] Ir no tema typescript fundamentos, ir para o tema fundamentos e acessar o exercício soma dobrada.
- [ ] Verificar se ao alterar o status é modificado no banco de dados.
- [ ] Ao atualizar a pagina recupera o status do banco de dados.
- [ ] Verificar qualidade do código.
- [ ] Aplicação não deve conter nenhum erro, warning ou console.log
- [ ] Alteração proposta no card foi implementada

Obs: Back end e Front end precisam está rodando para fazer as requisições.
