### PR TITLE
158/fix salvamento status backend

### DIFF
--- a/src/app/api/backend/updateExerciseStatus/route.ts
+++ b/src/app/api/backend/updateExerciseStatus/route.ts
@@ -7,6 +7,7 @@ export async function PUT(req: NextRequest) {
   const topicId = header.get(`topicId`)
   const itemId = header.get(`itemId`)
   const itemStatus = header.get(`itemStatus`)
+  const elementType = header.get(`elementType`)
   const accessToken = req.cookies.get("next-auth.session-token")?.value || req.cookies.get("__Secure-next-auth.session-token")?.value
 
   if (!topicId || !itemId) {
@@ -33,7 +34,7 @@ export async function PUT(req: NextRequest) {
           Authorization: `Bearer ${accessToken}`,
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ itemStatus }),
+        body: JSON.stringify({ itemStatus, elementType }),
       }
     )
 

--- a/src/components/ButtonCard/index.tsx
+++ b/src/components/ButtonCard/index.tsx
@@ -2,10 +2,11 @@ import * as React from "react"
 import Card from "@mui/material/Card"
 import CardContent from "@mui/material/CardContent"
 import Typography from "@mui/material/Typography"
-import { Box, CardActionArea} from "@mui/material"
+import { Box, CardActionArea } from "@mui/material"
 import { useRouter } from "next/navigation"
 import { theme } from "@/app/config/themes"
 import StatusSelect from "../StatusSelect"
+import { ElementType } from "@/types/typeTopic"
 
 interface ButtonCardProps {
     title: string
@@ -25,21 +26,21 @@ export const ButtonCard: React.FC<ButtonCardProps> = ({ title, description, rout
         router.push(`/${route}`)
     }
     return (
-        <Card sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'space-between',  ...theme.customStyles.cardButtonContainer }}>
-        <CardActionArea onClick={() => handleClick(route)} sx={{ flexGrow: 1 }}> 
-            <CardContent sx={theme.customStyles.cardButtonContent}>
-                <Typography gutterBottom variant="h3" component="div" sx={theme.customStyles.cardTitle}>
-                    {title}
-                </Typography>
-                <Typography variant="body1" sx={cardStyles}>
-                    {description}
-                </Typography>
-            </CardContent>
-        </CardActionArea>
-    
-        <Box sx={{ padding: 2 }}>
-            <StatusSelect id={id} width='70%'/>
-        </Box>
-    </Card>
+        <Card sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'space-between', ...theme.customStyles.cardButtonContainer }}>
+            <CardActionArea onClick={() => handleClick(route)} sx={{ flexGrow: 1 }}>
+                <CardContent sx={theme.customStyles.cardButtonContent}>
+                    <Typography gutterBottom variant="h3" component="div" sx={theme.customStyles.cardTitle}>
+                        {title}
+                    </Typography>
+                    <Typography variant="body1" sx={cardStyles}>
+                        {description}
+                    </Typography>
+                </CardContent>
+            </CardActionArea>
+
+            <Box sx={{ padding: 2 }}>
+                <StatusSelect elementType={ElementType.Exercise} id={id} width='70%' />
+            </Box>
+        </Card>
     );
 }

--- a/src/components/CardVideo/index.tsx
+++ b/src/components/CardVideo/index.tsx
@@ -3,6 +3,7 @@ import { Box, Typography } from "@mui/material"
 import { theme } from "@/app/config/themes"
 import ReactMarkdown from "react-markdown"
 import StatusSelect from "../StatusSelect"
+import { ElementType } from "@/types/typeTopic"
 
 const components = {
   h1: (props: React.HTMLAttributes<HTMLHeadingElement>) => (
@@ -53,7 +54,7 @@ export const CardVideo: React.FC<CardVideoProps> = ({
           <ReactMarkdown components={components}>{text}</ReactMarkdown>
         </Box>
         <Box sx={{ paddingTop: 2 }}>
-          <StatusSelect id={videoId} width="30%" /> 
+          <StatusSelect elementType={ElementType.Video} id={videoId} width="30%" />
         </Box>
       </Box>
     </Box>

--- a/src/components/PageElements/Content/DetailingExerciseContent/index.tsx
+++ b/src/components/PageElements/Content/DetailingExerciseContent/index.tsx
@@ -1,14 +1,15 @@
 import React from "react";
-import { Grid} from "@mui/material";
+import { Grid } from "@mui/material";
 import { BreadCrumb } from "@/components/BreadCrumb";
 import { ApiResponse, DataItem, ExercisesField } from "@/types/type";
 import { DescriptionFull } from "@/components/Description/DescriptionFull";
 import { ContainerButtonsExercise } from "../../Container/ContainerButtonsExercise";
 import { Heading } from "@/components/Heading";
 import StatusSelect from "@/components/StatusSelect";
+import { ElementType } from "@/types/typeTopic";
 
 interface DetailingContentProps {
-  dataTopic:ApiResponse
+  dataTopic: ApiResponse
   dataExercise: ApiResponse;
   id: string;
 }
@@ -17,7 +18,7 @@ const ExerciseContent: React.FC<{
   field: ExercisesField;
   idExercise: string;
   dataTopic: ApiResponse
-}> = ({ field, idExercise, dataTopic}) => (
+}> = ({ field, idExercise, dataTopic }) => (
   <>
     <Grid item xl={12} lg={12} md={12} sm={12} xs={12}>
       <BreadCrumb />
@@ -42,11 +43,11 @@ const ExerciseContent: React.FC<{
         <Heading variant="h1" text={field.title} />
       </Grid>
       <Grid item >
-        <StatusSelect width="100%"/>
+        <StatusSelect elementType={ElementType.Exercise} id={idExercise} width="100%" />
       </Grid>
     </Grid>
     <DescriptionFull text={field.description} />
-    <ContainerButtonsExercise idExercise={idExercise} data={dataTopic}/>
+    <ContainerButtonsExercise idExercise={idExercise} data={dataTopic} />
   </>
 );
 
@@ -63,9 +64,9 @@ export const DetailingExerciseContent: React.FC<DetailingContentProps> = ({
     <>
       {filteredData.map((element: DataItem) => (
         <ExerciseContent
-        dataTopic={dataTopic}
+          dataTopic={dataTopic}
           key={element.id}
-          idExercise={id}
+          idExercise={element.id}
           field={element.field as ExercisesField}
         />
       ))}

--- a/src/components/StatusSelect/index.tsx
+++ b/src/components/StatusSelect/index.tsx
@@ -11,19 +11,21 @@ import { usePathname } from "next/navigation"
 import { useStatus } from "@/components/fetchStatus/fetchStatusExercise"
 import { DetailingTopicContext } from "@/context"
 import { LoginWarningModal } from "../Modals/LoginWarningModal"
+import { ElementType } from "@/types/typeTopic"
 
 interface StatusSelectProps {
   width?: "30%" | "70%" | "100%"
   id?: string
+  elementType: ElementType
 }
 
-export default function StatusSelect({ width = "30%", id }: StatusSelectProps) {
+export default function StatusSelect({ width = "30%", id, elementType }: StatusSelectProps) {
   const [status, setStatus] = React.useState<string>("NotStarted")
   const [backgroundColor, setBackgroundColor] =
     React.useState<string>("rgb(225, 225, 225)")
   const [isModalOpen, setIsModalOpen] = React.useState<boolean>(false)
   const { data: session } = useSession()
-  const statusSelectRef = React.useRef<HTMLDivElement>(null)  
+  const statusSelectRef = React.useRef<HTMLDivElement>(null)
   const { topicStatus } = React.useContext(DetailingTopicContext)
   const pathname = usePathname()
 
@@ -47,22 +49,23 @@ export default function StatusSelect({ width = "30%", id }: StatusSelectProps) {
   const currentStatusTopic = topicStatus?.status?.find(
     (status) => status.itemId === id
   )
-  React.useEffect(()=>{
-    if(currentStatusTopic) {
+  React.useEffect(() => {
+    if (currentStatusTopic) {
       setStatus(currentStatusTopic?.itemStatus)
     }
   }, [currentStatusTopic])
- 
-  
+
+
   const extractIdsFromUrl = (pathname: string): string[] | null => {
     const parts: string[] = pathname.split("/")
 
-    if (parts.length === 5) {
-      const topicId = parts[3].split("-")[0]
-      const itemId = parts[4].split("-")[0] || ""
+    if (parts.length === 4) {
+      const topicId = parts[2].split("-")[0]
+      const itemId = parts[3].split("-")[0] || ""
 
       return (topicId && itemId) ? [topicId, itemId] : null
     }
+
     return null
   }
 
@@ -73,29 +76,29 @@ export default function StatusSelect({ width = "30%", id }: StatusSelectProps) {
     isLoading,
     updateStatus,
   } = useStatus({
-    topicId: ids?.[0] || "",
-    itemId: ids?.[1] || "",
+    topicId: ids?.[1] || "",
+    itemId: id || "",
   })
 
   const handleChange = async (event: SelectChangeEvent) => {
     const value = event.target.value as string
     setStatus(value)
 
-    if (!session && statusSelectRef.current) { 
+    if (!session && statusSelectRef.current) {
       statusSelectRef.current.classList.add("ativo")
       setIsModalOpen(true)
     }
 
     if (!ids) return
-    await updateStatus(value)
-  } 
 
-  const heandleCloseModals = () => {
-    if(statusSelectRef.current) {
+    await updateStatus(value, elementType)
+  }
+
+  const handleCloseModals = () => {
+    if (statusSelectRef.current) {
       statusSelectRef.current.classList.remove("ativo")
     }
 
-   
     setIsModalOpen(false)
     setStatus("NotStarted")
   }
@@ -148,7 +151,7 @@ export default function StatusSelect({ width = "30%", id }: StatusSelectProps) {
           Status
         </InputLabel>
         <Select
-          ref= {statusSelectRef}
+          ref={statusSelectRef}
           notched
           labelId="statusLeveling"
           id="statusSelect"
@@ -171,7 +174,7 @@ export default function StatusSelect({ width = "30%", id }: StatusSelectProps) {
           <MenuItem value="Completed">Concluído</MenuItem>
         </Select>
       </FormControl>
-      <LoginWarningModal status={status} open={isModalOpen} handleClose={heandleCloseModals}/>
+      <LoginWarningModal status={status} open={isModalOpen} handleClose={handleCloseModals} />
     </Box>
   )
 }

--- a/src/components/StatusSelect/index.tsx
+++ b/src/components/StatusSelect/index.tsx
@@ -29,23 +29,6 @@ export default function StatusSelect({ width = "30%", id, elementType }: StatusS
   const { topicStatus } = React.useContext(DetailingTopicContext)
   const pathname = usePathname()
 
-  React.useEffect(() => {
-    if (typeof window === "undefined") return
-
-    const statusValue = localStorage.getItem("statusValue") || "NotStarted"
-    const isActive = localStorage.getItem("activeStatusSelect") === "true"
-    const validStatuses = ["NotStarted", "InProgress", "Completed"]
-
-    if (statusSelectRef.current) {
-      if (session && isActive) {
-        setStatus(validStatuses.includes(statusValue) ? statusValue : "NotStarted")
-      }
-      statusSelectRef.current.classList.remove("ativo")
-      localStorage.removeItem("activeStatusSelect")
-      localStorage.removeItem("statusValue")
-    }
-  }, [session])
-
   const currentStatusTopic = topicStatus?.status?.find(
     (status) => status.itemId === id
   )
@@ -55,11 +38,10 @@ export default function StatusSelect({ width = "30%", id, elementType }: StatusS
     }
   }, [currentStatusTopic])
 
-
   const extractIdsFromUrl = (pathname: string): string[] | null => {
     const parts: string[] = pathname.split("/")
 
-    if (parts.length === 4) {
+    if (parts) {
       const topicId = parts[2].split("-")[0]
       const itemId = parts[3].split("-")[0] || ""
 

--- a/src/components/fetchStatus/fetchStatusExercise/index.ts
+++ b/src/components/fetchStatus/fetchStatusExercise/index.ts
@@ -1,3 +1,4 @@
+import { ElementType } from "@/types/typeTopic"
 import { useCallback, useEffect, useState } from "react"
 
 interface UseStatusProps {
@@ -39,7 +40,7 @@ export const useStatus = ({
     }
   }, [topicId, itemId])
 
-  const updateStatus = async (newStatus: string) => {
+  const updateStatus = async (newStatus: string,  elementType: ElementType) => {
     setIsLoading(true)
     setStatus(newStatus)
     try {
@@ -49,6 +50,7 @@ export const useStatus = ({
           topicId,
           itemId,
           itemStatus: newStatus,
+          elementType,
           "Content-Type": "application/json",
         },
       })

--- a/src/types/typeTopic.ts
+++ b/src/types/typeTopic.ts
@@ -2,7 +2,12 @@ export interface ApiTopic {
     status: StatusItem[] | []
 }
 export interface StatusItem {
-    elementType: string
+    elementType: ElementType
     itemId: string
     itemStatus: string
+}
+
+export enum ElementType {
+    Video = "Video",
+    Exercise = "Exercise"
 }


### PR DESCRIPTION
# 158 - fix: ajuste para que o salvamento de status acione os endpoints
====
  
### 🆙 CHANGELOG

 - **src/types/typeTopic.ts**: Criado enum para ElementType e corrigido o tipo do elementType na interface StatusItem.
 - [**src/app/api/backend/updateExerciseStatus/route.ts**, **src/components/fetchStatus/fetchStatusExercise/index.ts**] - elementType enviado no body das requisições, tanto a requisição feita ao backend quando a requisição feita ao backend do next.
- **src/components/StatusSelect/index.tsx** - Remoção do estado que gerenciava o status de forma local; Correção da função que extrai os id's de tópicos e itens da URL; Correção dos parâmetros passados para o hook useStatus, passando corretamente seus devidos valores.
 - [**src/components/ButtonCard/index.tsx**, **src/components/CardVideo/index.tsx**, **src/components/PageElements/Content/DetailingExerciseContent/index.tsx**] - ElementType passado como parâmetro do componente StatusSelect.

## ⚠️ Me certifico que:

- [x] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

*Esses passos são apenas exemplos*

- [ ] Fazer deploy em ambiente de teste
- [ ] Abrir URL da aplicação de teste
- [ ] Verificar modificação 1
- [ ] Verificar modificação 2
- [ ] Aplicação não deve conter nenhum erro, warning ou console.log
- [ ] Alteração proposta no card foi implementada
