### PR TITLE
281/visualizacao conteudo topics

### DIFF
--- a/src/app/api/topics/route.ts
+++ b/src/app/api/topics/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest) {
     try {

--- a/src/app/api/topics/route.ts
+++ b/src/app/api/topics/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+    try {
+
+        const searchParams = req.nextUrl.searchParams;
+
+        const page = searchParams.get("page")?.trim();
+        const limit = searchParams.get("limit")?.trim();
+
+        const query = new URLSearchParams();
+
+        if (page) query.set("page", page);
+        if (limit) query.set("limit", limit);
+
+        const baseUrl = process.env.BACKEND_BASE_URL;
+
+        const backendUrl = new URL("/topics", baseUrl);
+
+        if (query.toString()) {
+            backendUrl.search = query.toString();
+        }
+
+        const response = await fetch(backendUrl.toString(), {
+            method: "GET",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        });
+        if (!response.ok) {
+            return NextResponse.json(
+                { error: `Error fetching topics: ${response.status}` },
+                { status: response.status }
+            );
+        }
+        const data = await response.json();
+        return NextResponse.json({ data }, { status: 200 })
+    } catch (error) {
+        console.error("Error fetching topics:", error)
+        return NextResponse.json(
+            { error: "Internal server error" },
+            { status: 500 }
+        )
+    }
+}

--- a/src/app/cms/topics/page.tsx
+++ b/src/app/cms/topics/page.tsx
@@ -1,0 +1,9 @@
+"use client"
+
+import RenderCmsPage from "@/components/PageElements/cms/render-topic";
+
+export default function PageCms() {
+    return (
+        <RenderCmsPage />
+    )
+}

--- a/src/components/PageElements/cms/render-topic.tsx
+++ b/src/components/PageElements/cms/render-topic.tsx
@@ -1,0 +1,62 @@
+import { TableCMS } from "@/components/UI/cms/table-cms";
+import { UpperBanner } from "@/components/UI/cms/upper-banner";
+import { getTopics } from "@/utils/api/topics";
+import { Box } from "@mui/material";
+import { useEffect, useState } from "react";
+
+const columns = [
+  { id: "id", label: "ID" },
+  { id: "themeTitle", label: "Tema" },
+  { id: "title", label: "Título" },
+  { id: "shortDescription", label: "Descrição curta" },
+  { id: "isActive", label: "Ativo" },
+];
+
+export default function RenderCmsPage() {
+  const [rows, setRows] = useState<any[]>([]);
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(10);
+  const [rowCount, setRowCount] = useState(0);
+
+  useEffect(() => {
+    async function fetchTopics() {
+      try {
+        const res = await getTopics(page + 1, pageSize);
+        console.log("Topics response:", res.data);
+        const transformedData = res.data.map((topic: any) => ({
+          ...topic,
+          themeTitle: topic.theme?.title || "Sem tema",
+        }));
+        setRows(transformedData);
+        setRowCount(res.meta.total);
+      } catch (error) {
+        console.error("Erro ao buscar tópicos:", error);
+      } 
+    }
+    fetchTopics();
+  }, [page, pageSize]);
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      gap={"36px"}
+      sx={{ width: "100%"}}
+    >
+      <UpperBanner 
+        title="CMS - Tópicos"   
+        menuBanner 
+        createButton 
+      />
+      <TableCMS
+        columns={columns}
+        rows={rows}
+        page={page}
+        pageSize={pageSize}
+        rowCount={rowCount}
+        onPageChange={setPage}
+        onPageSizeChange={setPageSize}
+      />
+    </Box>
+  );
+}

--- a/src/components/PageElements/cms/render-topic.tsx
+++ b/src/components/PageElements/cms/render-topic.tsx
@@ -9,7 +9,7 @@ const columns: Column[] = [
   { id: "title", label: "Título" },
   { id: "themeTitle", label: "Tema" },
   { id: "shortDescription", label: "Descrição curta" },
-  { id: "isActive", label: "Ativo" },
+  { id: "themeID", label: "ID do tema" },
 ];
 
 export default function RenderCmsPage() {
@@ -22,12 +22,9 @@ export default function RenderCmsPage() {
     async function fetchTopics() {
       try {
         const res = await getTopics(page + 1, pageSize);
-        const transformedData = res.data.map((topic: any) => ({
-          ...topic,
-          themeTitle: topic.theme?.title || "Sem tema",
-        }));
-        setRows(transformedData);
-        setRowCount(res.meta.total);
+
+        setRows(res.data.data);
+        setRowCount(res.data.meta.total);
       } catch (error) {
         console.error("Erro ao buscar tópicos:", error);
       } 

--- a/src/components/PageElements/cms/render-topic.tsx
+++ b/src/components/PageElements/cms/render-topic.tsx
@@ -1,15 +1,15 @@
-import { TableCMS } from "@/components/UI/cms/table-cms";
+import { Column, TableCMS } from "@/components/UI/cms/table-cms";
 import { UpperBanner } from "@/components/UI/cms/upper-banner";
 import { getTopics } from "@/utils/api/topics";
 import { Box } from "@mui/material";
 import { useEffect, useState } from "react";
 
-const columns = [
+const columns: Column[] = [
   { id: "id", label: "ID" },
-  { id: "themeTitle", label: "Tema" },
   { id: "title", label: "Título" },
+  { id: "themeTitle", label: "Tema" },
   { id: "shortDescription", label: "Descrição curta" },
-  { id: "isActive", label: "Ativo" },
+  { id: "isActive", label: "Ativo", type: "boolean" },
 ];
 
 export default function RenderCmsPage() {

--- a/src/components/PageElements/cms/render-topic.tsx
+++ b/src/components/PageElements/cms/render-topic.tsx
@@ -22,7 +22,6 @@ export default function RenderCmsPage() {
     async function fetchTopics() {
       try {
         const res = await getTopics(page + 1, pageSize);
-        console.log("Topics response:", res.data);
         const transformedData = res.data.map((topic: any) => ({
           ...topic,
           themeTitle: topic.theme?.title || "Sem tema",

--- a/src/components/PageElements/cms/render-topic.tsx
+++ b/src/components/PageElements/cms/render-topic.tsx
@@ -9,7 +9,7 @@ const columns: Column[] = [
   { id: "title", label: "Título" },
   { id: "themeTitle", label: "Tema" },
   { id: "shortDescription", label: "Descrição curta" },
-  { id: "isActive", label: "Ativo", type: "boolean" },
+  { id: "isActive", label: "Ativo" },
 ];
 
 export default function RenderCmsPage() {

--- a/src/components/UI/cms/table-cms.tsx
+++ b/src/components/UI/cms/table-cms.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 export interface Column {
     id: string;
     label: string;
+    type?: 'string' | 'boolean' | 'number' | 'date';
 }
 
 export interface TableCMSProps {
@@ -27,12 +28,23 @@ export function TableCMS({ columns, rows, rowCount, pageSize, page, onPageChange
 
     const basePath = pathname.split("/")[2];
 
-    const gridColumns: GridColDef[] = columns.map((col) => ({
-        field: col.id,
-        headerName: col.label,
-        flex: 1,
-        sortable: true,
-    }));
+    const gridColumns: GridColDef[] = columns.map((col) => {
+        const baseColumn = {
+            field: col.id,
+            headerName: col.label,
+            flex: 1,
+            sortable: true,
+        };
+
+        if (col.type === 'boolean') {
+            return {
+                ...baseColumn,
+                renderCell: (params) => params.value ? 'true' : 'false',
+            };
+        }
+
+        return baseColumn;
+    });
 
     const gridRows = rows.map((row) => ({
         ...row,

--- a/src/components/UI/cms/table-cms.tsx
+++ b/src/components/UI/cms/table-cms.tsx
@@ -8,7 +8,6 @@ import React from 'react';
 export interface Column {
     id: string;
     label: string;
-    type?: 'string' | 'boolean' | 'number' | 'date';
 }
 
 export interface TableCMSProps {

--- a/src/components/UI/cms/table-cms.tsx
+++ b/src/components/UI/cms/table-cms.tsx
@@ -28,23 +28,12 @@ export function TableCMS({ columns, rows, rowCount, pageSize, page, onPageChange
 
     const basePath = pathname.split("/")[2];
 
-    const gridColumns: GridColDef[] = columns.map((col) => {
-        const baseColumn = {
-            field: col.id,
-            headerName: col.label,
-            flex: 1,
-            sortable: true,
-        };
-
-        if (col.type === 'boolean') {
-            return {
-                ...baseColumn,
-                renderCell: (params) => params.value ? 'true' : 'false',
-            };
-        }
-
-        return baseColumn;
-    });
+    const gridColumns: GridColDef[] = columns.map((col) => ({
+        field: col.id,
+        headerName: col.label,
+        flex: 1,
+        sortable: true,
+    }));
 
     const gridRows = rows.map((row) => ({
         ...row,

--- a/src/utils/api/topics.ts
+++ b/src/utils/api/topics.ts
@@ -1,0 +1,5 @@
+export async function getTopics(page: number, limit: number) {
+  const res = await fetch(`http://localhost:5002/topics?page=${page}&limit=${limit}`);
+  if (!res.ok) throw new Error("Erro ao buscar tópicos");
+  return res.json();
+}

--- a/src/utils/api/topics.ts
+++ b/src/utils/api/topics.ts
@@ -1,5 +1,9 @@
 export async function getTopics(page: number, limit: number) {
-  const res = await fetch(`http://localhost:5002/topics?page=${page}&limit=${limit}`);
+  const query = new URLSearchParams({
+    page: String(page),
+    limit: String(limit),
+  });
+  const res = await fetch(`/api/topics?${query.toString()}`);
   if (!res.ok) throw new Error("Erro ao buscar tópicos");
   return res.json();
 }


### PR DESCRIPTION
#<281> - Visualização de Conteudo Topics no table do Admin
====
  
### 🆙 CHANGELOG

- Coletado dados através da api de Topics para aparecer no table do Admin

## ⚠️ Me certifico que:

- [x] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [x] Fiz deploy para ambiente de teste certificando que o build não quebrou

## ⚠️ Como testar:

- [x] Fazer deploy em ambiente de teste, branch: 281/visualizacao-conteudo-topics
- [x] Abrir URL da aplicação de teste, http://localhost:3000/cms/topics
- [x] Verificar se conteúdo Topics aparece conforme API de Topics
- [x] Aplicação não deve conter nenhum erro, warning ou console.log
- [x] Alteração proposta no card foi implementada

## OBS:

- isActive de Topics está com erro no serviceTopics no Backend, estou encerrando o card agora, sem aparecer isActive no table do Admin, vou resolver o erro no serviceTopics no backend e depois implementar o isActive no table do admin para Topics.