### PR TITLE
Feat/api themes proxy query params

### DIFF
--- a/src/app/api/themes/route.ts
+++ b/src/app/api/themes/route.ts
@@ -4,34 +4,15 @@ import { NextRequest, NextResponse } from "next/server";
 export async function GET(req: NextRequest) {
   try {
     const searchParams = req.nextUrl.searchParams;
-    const rawCategory = searchParams.get("category")?.trim() || req.headers.get("category")?.trim();
+    const rawCategory = searchParams.get("category")?.trim();
     const page = searchParams.get("page")?.trim();
     const limit = searchParams.get("limit")?.trim();
 
-    const normalizeCategory = (value: string) =>
-      value
-        .normalize("NFD")
-        .replace(/[\u0300-\u036f]/g, "")
-        .toLowerCase()
-        .replace(/[\s_-]/g, "");
-
-    const categoryMap: Record<string, ThemeCategory> = {
-      nivelamento: ThemeCategory.LEVELING,
-      autoestudo: ThemeCategory.SELF_STUDY,
-      leveling: ThemeCategory.LEVELING,
-      selfstudy: ThemeCategory.SELF_STUDY,
-    };
-
-    let mappedCategory: ThemeCategory | undefined;
-    if (rawCategory) {
-      mappedCategory = categoryMap[normalizeCategory(rawCategory)];
-      if (!mappedCategory) {
-        return NextResponse.json(
-          { error: "Invalid category. Use Nivelamento or Autoestudo." },
-          { status: 400 }
-        );
-      }
-    }
+    const mappedCategory = rawCategory === "Nivelamento"
+      ? ThemeCategory.LEVELING
+      : rawCategory === "Autoestudo"
+        ? ThemeCategory.SELF_STUDY
+        : rawCategory;
 
     const backendQuery = new URLSearchParams();
     if (mappedCategory) backendQuery.set("category", mappedCategory);

--- a/src/app/api/themes/route.ts
+++ b/src/app/api/themes/route.ts
@@ -1,15 +1,51 @@
 import { ThemeCategory } from "@/utils/constants";
-import { headers } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(req: NextRequest) {
-  const header = headers();
-  const category = header.get("category") === "Nivelamento" ?
-            ThemeCategory.LEVELING
-          : ThemeCategory.SELF_STUDY;
   try {
-    const baseUrl = process.env.BACKEND_BASE_URL
-    const response = await fetch(`${baseUrl}/themes?category=${category}`, {
+    const searchParams = req.nextUrl.searchParams;
+    const rawCategory = searchParams.get("category")?.trim() || req.headers.get("category")?.trim();
+    const page = searchParams.get("page")?.trim();
+    const limit = searchParams.get("limit")?.trim();
+
+    const normalizeCategory = (value: string) =>
+      value
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .toLowerCase()
+        .replace(/[\s_-]/g, "");
+
+    const categoryMap: Record<string, ThemeCategory> = {
+      nivelamento: ThemeCategory.LEVELING,
+      autoestudo: ThemeCategory.SELF_STUDY,
+      leveling: ThemeCategory.LEVELING,
+      selfstudy: ThemeCategory.SELF_STUDY,
+    };
+
+    let mappedCategory: ThemeCategory | undefined;
+    if (rawCategory) {
+      mappedCategory = categoryMap[normalizeCategory(rawCategory)];
+      if (!mappedCategory) {
+        return NextResponse.json(
+          { error: "Invalid category. Use Nivelamento or Autoestudo." },
+          { status: 400 }
+        );
+      }
+    }
+
+    const backendQuery = new URLSearchParams();
+    if (mappedCategory) backendQuery.set("category", mappedCategory);
+    if (page) backendQuery.set("page", page);
+    if (limit) backendQuery.set("limit", limit);
+
+    const baseUrl = process.env.BACKEND_BASE_URL;
+    const backendUrl = new URL("/themes", baseUrl);
+    const queryString = backendQuery.toString();
+    if (queryString) {
+      backendUrl.search = queryString;
+    }
+
+    const response = await fetch(backendUrl.toString(), {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -22,8 +58,8 @@ export async function GET(req: NextRequest) {
         { status: response.status }
       )
     }
-    const data = await response.json();
-    return NextResponse.json({data}, { status: 200 })
+    const payload = await response.json();
+    return NextResponse.json(payload, { status: response.status });
   } catch (error) {
     console.error("Error fetching status:", error)
     return NextResponse.json(

--- a/src/hooks/useThemeApi.ts
+++ b/src/hooks/useThemeApi.ts
@@ -28,10 +28,9 @@ export function useThemeApi (category: string) {
     };
     if (flag_adminjs.enabled || (is_test_user && adminjs_preference)) {
       console.log("Flagsmith: 'flag_adminjs' HABILITADA. Chamando a rota de API /api/themes.");
-      url = `/api/themes`;
-      fetchOptions.headers = {
-        category,
-      };
+      const params = new URLSearchParams({ category });
+      url = `/api/themes?${params.toString()}`;
+      fetchOptions.headers = {};
     } else {
       console.log("Flagsmith: 'flag_adminjs' DESABILITADA. Chamando a rota de API /api/stackbyApi/Themes.");
       url = `/api/stackbyApi/Themes`;

--- a/src/utils/api/themes.ts
+++ b/src/utils/api/themes.ts
@@ -1,5 +1,9 @@
 export async function getThemes(page: number, limit: number) {
-  const res = await fetch(`http://localhost:5002/themes?page=${page}&limit=${limit}`);
+  const params = new URLSearchParams({
+    page: String(page),
+    limit: String(limit),
+  });
+  const res = await fetch(`/api/themes?${params.toString()}`);
   if (!res.ok) throw new Error("Erro ao buscar temas");
   return res.json();
 }


### PR DESCRIPTION
#315 - Ajusta proxy de themes para query params 
====

### 🆙 CHANGELOG

- Ajustado `GET /api/themes` para ler `category`, `page` e `limit` via query params
- Ajustado repasse de `category`, `page` e `limit` para o backend apenas quando informados
- Removido reempacotamento da resposta, retornando o payload original do backend com `data` e `meta`

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [ ] Fazer deploy em ambiente de teste
- [ ] Testar `GET /api/themes?page=1&limit=10`
- [ ] Verificar se a resposta retorna `data` e `meta`
- [ ] Verificar se `res.meta.total` está disponível
- [ ] Acessar `/cms/themes` e validar se a lista de temas aparece com paginação
- [ ] Testar `GET /api/themes?category=Nivelamento`
- [ ] Testar `GET /api/themes?category=Autoestudo`
- [ ] Validar que `/nivelamento` e `/autoestudo` continuam listando temas por categoria
- [ ] Aplicação não deve conter nenhum erro, warning ou console.log
- [ ] Alteração proposta no card foi implementada