### PR TITLE
feat(auth): aplica guard de autenticacao para rotas cms

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,41 +2,55 @@ import { NextResponse } from "next/server"
 import type { NextRequest } from "next/server"
 import { BACKEND_BASE_URL } from "./utils/constants"
 
+async function isSessionValid(sessionToken: string) {
+  try {
+    const response = await fetch(`${BACKEND_BASE_URL}/login`, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${sessionToken}`,
+        "Content-Type": "application/json",
+      },
+    })
+
+    return response.ok
+  } catch (error) {
+    console.error("Internal server error: ", error)
+    return false
+  }
+}
+
+function redirectToLogin(request: NextRequest) {
+  const callbackUrl = `${request.nextUrl.pathname}${request.nextUrl.search}`
+  const loginUrl = new URL("/login", request.url)
+  loginUrl.searchParams.set("callbackUrl", callbackUrl)
+  return NextResponse.redirect(loginUrl)
+}
+
 export async function middleware(request: NextRequest) {
   const sessionToken =
     request.cookies.get("next-auth.session-token") ||
     request.cookies.get("__Secure-next-auth.session-token")
 
-    const callbackUrl =
-    new URLSearchParams(request.nextUrl.search).get("callbackUrl") || "/"
+  const isLoginRoute = request.nextUrl.pathname.startsWith("/login")
+  const isCmsRoute = request.nextUrl.pathname.startsWith("/cms")
 
-    const parsedUrl = new URL(callbackUrl, request.url) 
+  if (isCmsRoute) {
+    if (!sessionToken) {
+      return redirectToLogin(request)
+    }
 
-  if (request.nextUrl.pathname.startsWith("/login") && sessionToken) {
-    try {
-      const response = await fetch(`${BACKEND_BASE_URL}/login`, {
-        method: "POST",
-        headers: {
-          "Authorization": `Bearer ${sessionToken.value}`,
-          "Content-Type": "application/json",
-        },
-      })
+    const validSession = await isSessionValid(sessionToken.value)
+    if (!validSession) {
+      return redirectToLogin(request)
+    }
+  }
 
-      if (response.status === 401) {
-        return NextResponse.json(
-          { error: "Unauthorized: Invalid or expired token" },
-          { status: 401 }
-        )
-      } 
-      
-      if (!response.ok) {
-        return NextResponse.json({ error: "Failed to register user" }, { status: response.status })
-      }
+  if (isLoginRoute && sessionToken) {
+    const callbackUrl = request.nextUrl.searchParams.get("callbackUrl") || "/"
+    const validSession = await isSessionValid(sessionToken.value)
 
-      return NextResponse.redirect(new URL(parsedUrl, request.url))
-    } catch (error) {
-      console.error("Internal server error: ", error)
-      return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+    if (validSession) {
+      return NextResponse.redirect(new URL(callbackUrl, request.url))
     }
   }
 
@@ -44,5 +58,5 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/login"],
+  matcher: ["/login", "/cms/:path*"],
 }


### PR DESCRIPTION
#318 - Guard de autenticação para rotas administrativas CMS
====

### 🆙 CHANGELOG

- Adicionado guard de autenticação para rotas com prefixo `/cms/*`
- Implementado redirecionamento para `/login` quando não há sessão válida
- Preservação de `callbackUrl` para retorno após login
- Ajustado middleware para cobrir rotas administrativas além de `/login`
- Garantida proteção contra acesso direto, refresh e navegação interna sem autenticação
- Evitado flash de conteúdo administrativo antes da validação

---

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

---

## ⚠️ Como testar:

- [ ] Fazer deploy em ambiente de teste
- [ ] Tentar acessar `/cms` ou qualquer rota `/cms/*` sem estar logado
- [ ] Verificar redirecionamento para `/login`
- [ ] Verificar se o `callbackUrl` foi preservado corretamente
- [ ] Após login, validar se o usuário retorna para a rota original
- [ ] Acessar `/cms/*` com usuário logado e validar acesso normal
- [ ] Fazer refresh em `/cms/*` e validar que a autenticação é mantida
- [ ] Navegar internamente para `/cms/*` sem sessão e validar bloqueio
- [ ] Verificar que rotas públicas continuam funcionando normalmente
- [ ] Validar que não ocorre flash de conteúdo administrativo
- [ ] Aplicação não deve conter nenhum erro, warning ou console.log
- [ ] Alteração proposta no card foi implementada