### PR TITLE
#320 - [BUG] Frontend: Inconsistência na listagem de temas devido à coexistência de fluxos Stackby e CMS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@
 .DS_Store
 *.pem
 
+# docs internos (não versionar)
+filtragem-categoria-temas-interno.md
+
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/src/app/api/themes/route.ts
+++ b/src/app/api/themes/route.ts
@@ -2,17 +2,30 @@ import { ThemeCategory } from "@/utils/constants";
 import { headers } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 
-
-//** TODO
-// fazer com que essa chamada, se não for passado nenhuma categoria, traga todos os temas */
 export async function GET(req: NextRequest) {
   const header = headers();
-  const category = header.get("category") === "Nivelamento" ?
-            ThemeCategory.LEVELING
-          : ThemeCategory.SELF_STUDY;
+  const categoryHeader = header.get("category");
+
+  const categoryMap: Record<string, ThemeCategory> = {
+    Nivelamento: ThemeCategory.LEVELING,
+    Autoestudo: ThemeCategory.SELF_STUDY,
+  };
+
+  const category = categoryHeader ? categoryMap[categoryHeader] : undefined;
+
   try {
-    const baseUrl = process.env.BACKEND_BASE_URL
-    const response = await fetch(`${baseUrl}/themes?category=${category}`, {
+    const baseUrl = process.env.BACKEND_BASE_URL;
+
+    const url = category
+      ? `${baseUrl}/themes?category=${category}`
+      : `${baseUrl}/themes`;
+
+  
+    console.log("categoryHeader:", categoryHeader);
+    console.log("category mapeada:", category);
+    console.log("url chamada:", url);
+
+    const response = await fetch(url, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -21,25 +34,31 @@ export async function GET(req: NextRequest) {
 
     if (!response.ok) {
       return NextResponse.json(
-        { error: `Error fetching status: ${response.status} - ${response.statusText}` },
+        {
+          error: `Error fetching themes: ${response.status} - ${response.statusText}`,
+        },
         { status: response.status }
-      )
+      );
     }
+
     const data = await response.json();
-    return NextResponse.json({data}, { status: 200 })
+
+    return NextResponse.json({ data }, { status: 200 });
   } catch (error) {
-    console.error("Error fetching status:", error)
+    console.error("Error fetching themes:", error);
+
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 }
-    )
+    );
   }
 }
 
 export async function POST(req: NextRequest) {
   try {
-    const accessToken = req.cookies.get("next-auth.session-token")?.value ||
-                        req.cookies.get("__Secure-next-auth.session-token")?.value;
+    const accessToken =
+      req.cookies.get("next-auth.session-token")?.value ||
+      req.cookies.get("__Secure-next-auth.session-token")?.value;
 
     if (!accessToken) {
       return NextResponse.json(
@@ -55,26 +74,35 @@ export async function POST(req: NextRequest) {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "Authorization": `Bearer ${accessToken}`,
+        Authorization: `Bearer ${accessToken}`,
       },
       body: JSON.stringify(body),
     });
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
+
       return NextResponse.json(
-        { error: errorData.message || `Error creating theme: ${response.statusText}` },
+        {
+          error:
+            errorData.message ||
+            `Error creating theme: ${response.statusText}`,
+        },
         { status: response.status }
       );
     }
 
     const data = await response.json();
+
     return NextResponse.json(data, { status: 201 });
   } catch (error) {
     console.error("Error creating theme:", error);
+
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 }
     );
   }
 }
+
+/*Ajustei a rota intermediária para mapear corretamente os valores de categoria enviados pelo front (em português) para os valores esperados pelo backend (enum em inglês). Antes, qualquer valor diferente de "Nivelamento" estava caindo como "SelfStudy", o que podia causar mistura de dados.*/

--- a/src/app/api/themes/route.ts
+++ b/src/app/api/themes/route.ts
@@ -20,11 +20,6 @@ export async function GET(req: NextRequest) {
       ? `${baseUrl}/themes?category=${category}`
       : `${baseUrl}/themes`;
 
-  
-    console.log("categoryHeader:", categoryHeader);
-    console.log("category mapeada:", category);
-    console.log("url chamada:", url);
-
     const response = await fetch(url, {
       method: "GET",
       headers: {

--- a/src/components/PageElements/Container/ContainerCardsThemes/index.tsx
+++ b/src/components/PageElements/Container/ContainerCardsThemes/index.tsx
@@ -16,10 +16,21 @@ export const ContainerCardTheme: React.FC<ContainerCardThemeProps> = ({
   const pathname = usePathname();
   const currentPath = pathname.slice(1);
   const { adminjs_preference } = useFlags([""], ["adminjs_preference"]);
+  const themes = Array.isArray(data.data)
+    ? data.data
+    : Array.isArray((data.data as any)?.data)
+      ? (data.data as any).data
+      : [];
+
+  const filteredData = themes.filter((element: DataItem) => {
+    const theme = element?.field as ThemeField | undefined;
+    return theme?.category === category;
+  });
+
   return (
     <Grid container spacing={2} alignItems="stretch">
       {!adminjs_preference
-        ? data.data.map((element: DataItem, index: number) => {
+        ? filteredData.map((element: DataItem, index: number) => {
             const field = element?.field as ThemeField;
             return (
               <Grid item xl={3} lg={4} md={4} sm={6} xs={12} key={index}>
@@ -36,7 +47,7 @@ export const ContainerCardTheme: React.FC<ContainerCardThemeProps> = ({
             );
           })
         : (
-            data.data as unknown as Array<{
+            (themes as unknown as Array<{
               id: string;
               title: string;
               shortDescription: string;
@@ -45,7 +56,7 @@ export const ContainerCardTheme: React.FC<ContainerCardThemeProps> = ({
               category: string;
               sequence: number;
               alt: string;
-            }>
+            }>).filter((element) => element.category === category)
           ).map((element, index) => (
               <Grid item xl={3} lg={4} md={4} sm={6} xs={12} key={index}>
                 <BaseCard

--- a/src/components/PageElements/Container/ContainerCardsThemes/index.tsx
+++ b/src/components/PageElements/Container/ContainerCardsThemes/index.tsx
@@ -16,59 +16,59 @@ export const ContainerCardTheme: React.FC<ContainerCardThemeProps> = ({
   const pathname = usePathname();
   const currentPath = pathname.slice(1);
   const { adminjs_preference } = useFlags([""], ["adminjs_preference"]);
-  const themes = Array.isArray(data.data)
-    ? data.data
-    : Array.isArray((data.data as any)?.data)
-      ? (data.data as any).data
-      : [];
+  const themes = data.data 
 
-  const filteredData = themes.filter((element: DataItem) => {
-    const theme = element?.field as ThemeField | undefined;
-    return theme?.category === category;
-  });
+  if (!adminjs_preference) {
+    const filteredData = data.data.filter((element: DataItem) => {
+      const theme = element?.field as ThemeField | undefined;
+      return theme?.category === category;
+    });
+
+    return (
+      <Grid container spacing={2} alignItems="stretch">
+        {filteredData.map((element: DataItem, index: number) => {
+          const field = element?.field as ThemeField;
+          return (
+            <Grid item xl={3} lg={4} md={4} sm={6} xs={12} key={index}>
+              <BaseCard
+                id={element.id}
+                title={field?.title}
+                description={field?.cardDescription}
+                route={`${currentPath}/${element.id}-${field?.title}`}
+                image={field?.image ? field.image[0].url : ""}
+                textImage={`${field?.alt}`}
+                cardType="theme"
+              />
+            </Grid>
+          );
+        })}
+      </Grid>
+    );
+  }
 
   return (
     <Grid container spacing={2} alignItems="stretch">
-      {!adminjs_preference
-        ? filteredData.map((element: DataItem, index: number) => {
-            const field = element?.field as ThemeField;
-            return (
-              <Grid item xl={3} lg={4} md={4} sm={6} xs={12} key={index}>
-                <BaseCard
-                  id={element.id}
-                  title={field?.title}
-                  description={field?.cardDescription}
-                  route={`${currentPath}/${element.id}-${field?.title}`}
-                  image={field?.image ? field.image[0].url : ""}
-                  textImage={`${field?.alt}`}
-                  cardType="theme"
-                />
-              </Grid>
-            );
-          })
-        : (
-            (themes as unknown as Array<{
-              id: string;
-              title: string;
-              shortDescription: string;
-              cardDescription: string;
-              image: string;
-              category: string;
-              sequence: number;
-              alt: string;
-            }>).filter((element) => element.category === category)
-          ).map((element, index) => (
-              <Grid item xl={3} lg={4} md={4} sm={6} xs={12} key={index}>
-                <BaseCard
-                  id={element.id}
-                  title={element.title}
-                  description={element?.shortDescription}
-                  image={element.image}
-                  textImage={`${element?.alt}`}
-                  cardType="theme"
-                />
-              </Grid>
-            ))}
+      {(data.data as unknown as Array<{
+        id: string;
+        title: string;
+        shortDescription: string;
+        cardDescription: string;
+        image: string;
+        category: string;
+        sequence: number;
+        alt: string;
+      }>).filter((element) => element.category === category).map((element, index) => (
+        <Grid item xl={3} lg={4} md={4} sm={6} xs={12} key={index}>
+          <BaseCard
+            id={element.id}
+            title={element.title}
+            description={element?.shortDescription}
+            image={element.image}
+            textImage={`${element?.alt}`}
+            cardType="theme"
+          />
+        </Grid>
+      ))}
     </Grid>
   );
 };

--- a/src/components/PageElements/Container/ContainerCardsThemes/index.tsx
+++ b/src/components/PageElements/Container/ContainerCardsThemes/index.tsx
@@ -1,13 +1,10 @@
 import { Grid } from "@mui/material";
 import React from "react";
 import { BaseCard } from "@/components/BaseCard";
-import { ApiResponse, DataItem, ThemeField } from "@/types/type";
+import { ApiResponse, ContainerCardThemeProps ,DataItem, DatabaseThemesResponse, ThemeField } from "@/types/type";
 import { usePathname } from "next/navigation";
 import { useFlags } from "flagsmith/react";
-interface ContainerCardThemeProps {
-  data: ApiResponse;
-  category: string;
-}
+
 
 export const ContainerCardTheme: React.FC<ContainerCardThemeProps> = ({
   data,
@@ -16,14 +13,23 @@ export const ContainerCardTheme: React.FC<ContainerCardThemeProps> = ({
   const pathname = usePathname();
   const currentPath = pathname.slice(1);
   const { adminjs_preference } = useFlags([""], ["adminjs_preference"]);
-  const themes = data.data 
 
-  if (!adminjs_preference) {
+function isApiResponse(data: any): data is ApiResponse {
+  return Array.isArray(data.data);
+}
+
+function isDatabaseThemesResponse(data: any): data is DatabaseThemesResponse {
+  return data.data && Array.isArray(data.data.data);
+}
+
+
+  
+  if (!adminjs_preference && isApiResponse(data)) {
     const filteredData = data.data.filter((element: DataItem) => {
-      const theme = element?.field as ThemeField | undefined;
+      const theme = element?.field as ThemeField;
       return theme?.category === category;
     });
-
+    
     return (
       <Grid container spacing={2} alignItems="stretch">
         {filteredData.map((element: DataItem, index: number) => {
@@ -48,16 +54,7 @@ export const ContainerCardTheme: React.FC<ContainerCardThemeProps> = ({
 
   return (
     <Grid container spacing={2} alignItems="stretch">
-      {(data.data as unknown as Array<{
-        id: string;
-        title: string;
-        shortDescription: string;
-        cardDescription: string;
-        image: string;
-        category: string;
-        sequence: number;
-        alt: string;
-      }>).filter((element) => element.category === category).map((element, index) => (
+      {isDatabaseThemesResponse(data) && data.data.data.map((element, index) => (
         <Grid item xl={3} lg={4} md={4} sm={6} xs={12} key={index}>
           <BaseCard
             id={element.id}
@@ -72,3 +69,5 @@ export const ContainerCardTheme: React.FC<ContainerCardThemeProps> = ({
     </Grid>
   );
 };
+
+

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -1,5 +1,29 @@
+export interface DatabaseTheme {
+        id: string;
+        title: string;
+        shortDescription: string;
+        cardDescription: string;
+        image: string;
+        category: string;
+        sequence: number;
+        alt: string;
+}
+
+export interface DatabaseThemesResponse {
+  data: {
+    data: DatabaseTheme[]
+  };
+}
+
+export type CardThemeData = ApiResponse | DatabaseThemesResponse;
+
 export interface ApiResponse {
     data: DataItem[];
+}
+
+export interface ContainerCardThemeProps {
+  data: CardThemeData;
+  category: string;
 }
 
 export interface DataItem {


### PR DESCRIPTION
#320 - [BUG] Frontend: Inconsistência na listagem de temas devido à coexistência de fluxos Stackby e CMS 
====
  
### 🆙 CHANGELOG

## Sobre a troca de /status para /themes
- A rota /themes passou a ser usada para buscar temas/trilhas, substituindo qualquer uso antigo de /status para essa finalidade.
- O termo "status" permanece no projeto, mas está relacionado a progresso do usuário, status de tópicos, exercícios ou respostas HTTP, e não à listagem de temas.
- Essa mudança foi feita para alinhar o front-end ao padrão do backend e evitar ambiguidades, garantindo que cada endpoint e variável tenha um propósito claro.
- Não há impacto negativo em outras áreas do código, pois "status" e "themes" são usados em contextos diferentes.
# DOCS: Filtragem de Temas por Categoria (Nivelamento/Autoestudo)

## O que foi feito
- **Filtro por categoria no front-end:**
	- Alterado o componente `ContainerCardTheme` (`src/components/PageElements/Container/ContainerCardsThemes/index.tsx`) para filtrar os temas recebidos, exibindo apenas aqueles cuja propriedade `category` corresponde exatamente à categoria recebida pela página ("Nivelamento" ou "Autoestudo").
- **Tratamento de diferentes formatos de resposta:**
	- Como a resposta da API pode variar dependendo da flag do Flagsmith (`flag_adminjs`), foi implementada uma lógica para garantir que sempre será utilizado um array de temas, seja em `data.data` ou `data.data.data`.
- **Proteção contra dados inconsistentes:**
	- O filtro agora utiliza optional chaining (`theme?.category`) para evitar erros caso algum item não possua o campo `field` ou `category`.

## Onde foi alterado
- **src/components/PageElements/Container/ContainerCardsThemes/index.tsx**
	- Adicionado o filtro seguro antes do `.map()` para garantir que apenas temas da categoria correta sejam exibidos.
	- Lógica para tratar diferentes formatos de resposta da API.
	- Uso de optional chaining para evitar quebras em dados incompletos.

## Por que foi feito
- A API pode retornar temas de ambas as categorias misturados, especialmente quando a filtragem no backend não está garantida ou a flag do Flagsmith está desabilitada.
- O filtro no front-end garante que cada página mostre apenas os temas da categoria correta, independentemente do formato ou conteúdo retornado pela API.
- Assegura robustez contra mudanças futuras no backend ou Flagsmith, evitando que a tela quebre ou exiba dados incorretos.
- Corrige erros como:
	- `data.data.filter is not a function`
	- `Cannot read properties of undefined (reading 'category')`

## Backend
- O backend já estava correto: o endpoint `/themes` filtra os temas/trilhas pelo parâmetro `category`, aceitando apenas os valores em inglês (`Leveling` para Nivelamento e `SelfStudy` para Autoestudo).
- Não há lógica condicional baseada em Flagsmith no backend para essa rota, então funciona igual com a flag ativada ou desativada.
- Se o front enviar valores em português, o backend retorna erro de validação.


## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:
Use as URLs abaixo (ajuste o host se necessário):

- Temas de Nivelamento:
	http://localhost:5002/themes?category=Leveling
- Temas de Autoestudo:
	http://localhost:5002/themes?category=SelfStudy
- Valor inválido (deve dar erro):
	http://localhost:5002/themes?category=Nivelamento
	http://localhost:5002/themes?category=Autoestudo
- Todos os temas (sem filtro):
	http://localhost:5002/themes