### PR TITLE
feat: implementado role do usuário na autenticação NextAuth 

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,7 @@
 import NextAuth from "next-auth"
 import { getAuthProviders } from "../../../helpers/providers"
 
+
 const handler = NextAuth({
   providers: getAuthProviders(),
   callbacks: {
@@ -9,8 +10,28 @@ const handler = NextAuth({
         token.id = user.id
         token.provider = account.provider
         token.accessToken = account.access_token
+
+        if (user) {
+
+          const role = await fetch(`${process.env.NEXTAUTH_URL}/api/user/getRole`, {
+            method: 'GET',
+            headers: {
+              'Content-Type': 'application/json',
+              email: user.email || '',
+            },
+          })
+          const userData = await role.json()
+
+          token.role = userData.role;
+        }
+
       }
+
       return token
+    },
+    session: ({ session, token }) => {
+      session.user.role = token.role
+      return session
     },
   },
 })

--- a/src/app/api/user/getRole/route.ts
+++ b/src/app/api/user/getRole/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { headers } from 'next/headers';
+
+export async function GET(req: NextRequest) {
+    const header = headers()
+    try {
+
+        const baseUrl = process.env.BACKEND_BASE_URL
+
+        const response = await fetch(`${baseUrl}/user/role`, {
+            headers: {
+                email: header.get('email') || '',
+            },
+        })
+        const userData = await response.json()
+
+
+        return NextResponse.json({ role: userData.role }, { status: 200 })
+
+
+    } catch (error) {
+
+        console.error("Error fetching user role:", error)
+        return NextResponse.json({ error }, { status: 500 })
+
+    }
+}

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -9,6 +9,13 @@ declare module "next-auth" {
     user: {
       /** Oauth access token */
       token?: accessToken;
+      role?: string;
     } & DefaultSession["user"];
   }
 }
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    role?: string;
+  }
+} 


### PR DESCRIPTION
#81 (do backend) - implementado role do usuário na autenticação NextAuth  @andrea-leite

====
  
### 🆙 CHANGELOG

- Adicionada a rota interna `/api/user/getRole` para fazer proxy da consulta de role do backend.
- Atualizado o callback do NextAuth para buscar o role no login e armazenar em `token.role`.
- Propagado o role para `session.user.role` durante a sessão.
- Ajustados os tipos do NextAuth para incluir `role` no `JWT` e na `Session`

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

*Esses passos são apenas exemplos*

- [ ] Rodar o backend e o frontend localmente
- [ ] Abrir Prisma studio para testar as autorizações de diferentes roles
- [ ] Logar com seu usuário
- [ ] Acessar a URL (http://localhost:3000/cms/themes/create)
- [ ] Preencher o formulário corretamente.
- [ ] Viewer retorna: erro de permissão para criar o tema
- [ ] Editor/Admin retorna: tema criado, usuário encaminhado para página de lista de temas, tema aparece na lista.
