### PR TITLE
feat: display theme in exercises table

### DIFF
--- a/src/components/PageElements/cms/exercises/render-exercises.tsx
+++ b/src/components/PageElements/cms/exercises/render-exercises.tsx
@@ -12,7 +12,7 @@ const columns = [
   { id: "description", label: "Descrição" },
   { id: "shortDescription", label: "Descrição curta" },
   { id: "topic", label: "Tópico" },
-  /* { id: "theme", label: "Tema" }, */
+  { id: "theme", label: "Tema" },
   { id: "isActive", label: "Ativo" },
 ];
 
@@ -27,13 +27,22 @@ export default function RenderCmsPage() {
       try {
         const res = await getExercises(page + 1, pageSize);
 
-        setRows(res.data.data);
+        const formattedRows = res.data.data.map((exercise: any) => ({
+          ...exercise,
+          topic: exercise.topic?.title ?? exercise.topic?.name ?? "-",
+          theme:
+            exercise.topic?.theme?.title ??
+            exercise.topic?.theme?.name ??
+            "-",
+        }));
+
+        setRows(formattedRows);
         setRowCount(res.data.meta.total);
-        
       } catch (error) {
         console.error("Erro ao buscar exercícios:", error);
       }
     }
+
     fetchExercises();
   }, [page, pageSize]);
 
@@ -44,11 +53,7 @@ export default function RenderCmsPage() {
       gap={"36px"}
       sx={{ width: "100%" }}
     >
-      <UpperBanner
-        title="CMS - Exercícios"
-        menuBanner
-        createButton
-      />
+      <UpperBanner title="CMS - Exercícios" menuBanner createButton />
       <TableCMS
         columns={columns}
         rows={rows}
@@ -60,4 +65,4 @@ export default function RenderCmsPage() {
       />
     </Box>
   );
-}   
+}


### PR DESCRIPTION
#<NUMERO-DO-CARD> - Exibir tópico e tema na listagem de exercícios

====

### 🆙 CHANGELOG

- Habilitada a exibição da coluna **Tema** na tabela de exercícios do CMS.
- Ajustado o mapeamento dos dados retornados pela API para exibir corretamente **Tópico** e **Tema**.
- Mantida a compatibilidade com a paginação e navegação existentes na listagem.

## ⚠️ Me certifico que:

- [x] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [x] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [x] Fazer deploy em ambiente de teste
- [x] Abrir a tela **CMS > Exercícios**
- [x] Verificar se a coluna **Tópico** é exibida corretamente
- [x] Verificar se a coluna **Tema** é exibida corretamente
- [x] Validar que a paginação continua funcionando normalmente
- [x] Validar que o fluxo de visualização e edição permanece funcionando
- [x] Alteração proposta no card foi implementada