### PR TITLE
346 fix admin topicos ordenamento deve ser para toda a lista

### DIFF
--- a/src/app/api/topics/route.ts
+++ b/src/app/api/topics/route.ts
@@ -53,11 +53,15 @@ export async function GET(req: NextRequest) {
 
         const page = searchParams.get("page")?.trim();
         const limit = searchParams.get("limit")?.trim();
+        const sortBy = searchParams.get("sortBy")?.trim();
+        const sortOrder = searchParams.get("sortOrder")?.trim();
 
         const query = new URLSearchParams();
 
         if (page) query.set("page", page);
         if (limit) query.set("limit", limit);
+        if (sortBy) query.set("sortBy", sortBy);
+        if (sortOrder) query.set("sortOrder", sortOrder);
 
         const baseUrl = process.env.BACKEND_BASE_URL;
 

--- a/src/app/cms/exercises/[id]/edit/page.tsx
+++ b/src/app/cms/exercises/[id]/edit/page.tsx
@@ -10,7 +10,7 @@ export default function Page({ params }: PageProps) {
   return (
     <DetailExercise 
       id={params.id} 
-      isEditing // Isso vai habilitar os campos automaticamente!
+      isEditing
     />
   );
 }

--- a/src/components/PageElements/cms/topics/render-topic.tsx
+++ b/src/components/PageElements/cms/topics/render-topic.tsx
@@ -3,11 +3,12 @@ import { UpperBanner } from "@/components/UI/cms/upper-banner";
 import { getTopics } from "@/utils/api/topics";
 import { Box } from "@mui/material";
 import { useEffect, useState } from "react";
+import type { GridSortModel } from "@mui/x-data-grid";
 
 const columns: Column[] = [
   { id: "id", label: "ID" },
   { id: "title", label: "Título" },
-  { id: "themeTitle", label: "Tema" },
+  { id: "themeTitle", label: "Tema", sortable: false },
   { id: "shortDescription", label: "Descrição curta" },
   { id: "themeID", label: "ID do tema" },
 ];
@@ -17,11 +18,21 @@ export default function RenderCmsPage() {
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(10);
   const [rowCount, setRowCount] = useState(0);
+  const [sortModel, setSortModel] = useState<GridSortModel>([]);
+
+  const handleSortModelChange = (newModel: GridSortModel) => {
+    setSortModel(newModel);
+    setPage(0);
+  };
 
   useEffect(() => {
     async function fetchTopics() {
       try {
-        const res = await getTopics(page + 1, pageSize);
+        const sortBy = sortModel[0]?.field;
+        const sortOrder = sortModel[0]?.sort;
+        const res = await getTopics(page + 1, pageSize, sortBy, sortOrder);
+        //TO-DO: FIX SORTORDER PARAM TYPE
+        //TEST WITH npm run build
 
         setRows(res.data.data);
         setRowCount(res.data.meta.total);
@@ -30,7 +41,7 @@ export default function RenderCmsPage() {
       } 
     }
     fetchTopics();
-  }, [page, pageSize]);
+  }, [page, pageSize, sortModel]);
 
   return (
     <Box
@@ -52,6 +63,8 @@ export default function RenderCmsPage() {
         rowCount={rowCount}
         onPageChange={setPage}
         onPageSizeChange={setPageSize}
+        sortModel={sortModel}
+        onSortModelChange={handleSortModelChange}
       />
     </Box>
   );

--- a/src/components/PageElements/cms/topics/render-topic.tsx
+++ b/src/components/PageElements/cms/topics/render-topic.tsx
@@ -31,8 +31,6 @@ export default function RenderCmsPage() {
         const sortBy = sortModel[0]?.field;
         const sortOrder = sortModel[0]?.sort;
         const res = await getTopics(page + 1, pageSize, sortBy, sortOrder);
-        //TO-DO: FIX SORTORDER PARAM TYPE
-        //TEST WITH npm run build
 
         setRows(res.data.data);
         setRowCount(res.data.meta.total);

--- a/src/components/UI/cms/table-cms.tsx
+++ b/src/components/UI/cms/table-cms.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { DataGrid, GridColDef } from '@mui/x-data-grid';
+import { DataGrid, GridColDef, GridSortModel } from '@mui/x-data-grid';
 import { ptBR } from '@mui/x-data-grid/locales';
 import { Paper, useTheme } from '@mui/material';
 import { usePathname, useRouter  } from 'next/navigation';
@@ -8,6 +8,7 @@ import React from 'react';
 export interface Column {
     id: string;
     label: string;
+    sortable?: boolean;
 }
 
 export interface TableCMSProps {
@@ -18,9 +19,11 @@ export interface TableCMSProps {
     page: number;
     onPageChange: (newPage: number) => void;
     onPageSizeChange: (newPageSize: number) => void;
+    sortModel?: GridSortModel;
+    onSortModelChange?: (model: GridSortModel) => void;
 }
 
-export function TableCMS({ columns, rows, rowCount, pageSize, page, onPageChange, onPageSizeChange }: TableCMSProps) {
+export function TableCMS({ columns, rows, rowCount, pageSize, page, onPageChange, onPageSizeChange, sortModel, onSortModelChange }: TableCMSProps) {
     const router = useRouter();
     const theme = useTheme();
     const pathname = usePathname();
@@ -31,7 +34,7 @@ export function TableCMS({ columns, rows, rowCount, pageSize, page, onPageChange
         field: col.id,
         headerName: col.label,
         flex: 1,
-        sortable: true,
+        sortable: col.sortable ?? true,
     }));
 
     const gridRows = rows.map((row) => ({
@@ -51,6 +54,9 @@ export function TableCMS({ columns, rows, rowCount, pageSize, page, onPageChange
                     onPageChange(model.page);
                     onPageSizeChange(model.pageSize);
                 }}
+                sortingMode={sortModel !== undefined ? "server" : undefined}
+                sortModel={sortModel}
+                onSortModelChange={onSortModelChange}
                 pageSizeOptions={[10, 25, 50]}
                 disableRowSelectionOnClick
                 onRowClick={(params) => router.push(`/cms/${basePath}/${params.id}`)}

--- a/src/utils/api/topics.ts
+++ b/src/utils/api/topics.ts
@@ -1,4 +1,4 @@
-import { error } from "console";
+import { GridSortDirection } from "@mui/x-data-grid";
 
 export async function createTopic(topicData: {
     title: string;
@@ -22,7 +22,7 @@ export async function createTopic(topicData: {
     return res.json();
 }
 
-export async function getTopics(page: number, limit: number, sortBy?: string, sortOrder?: string) {
+export async function getTopics(page: number, limit: number, sortBy?: string, sortOrder?: GridSortDirection) {
   const query = new URLSearchParams({
     page: String(page),
     limit: String(limit),

--- a/src/utils/api/topics.ts
+++ b/src/utils/api/topics.ts
@@ -22,11 +22,13 @@ export async function createTopic(topicData: {
     return res.json();
 }
 
-export async function getTopics(page: number, limit: number) {
+export async function getTopics(page: number, limit: number, sortBy?: string, sortOrder?: string) {
   const query = new URLSearchParams({
     page: String(page),
     limit: String(limit),
   });
+  if (sortBy) query.set("sortBy", sortBy);
+  if (sortOrder) query.set("sortOrder", sortOrder);
   const res = await fetch(`/api/topics?${query.toString()}`);
   if (!res.ok) throw new Error("Erro ao buscar tópicos");
   return res.json();


### PR DESCRIPTION
#346 - fix: admin: tópicos: ordenamento deve ser para toda a lista (não somente para a página)
====
  
### 🆙 CHANGELOG

*Esses passos são apenas exemplos*

- Adiciona ordenamento ao render-tópic.tsx


## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:


- [ ] Rodar o frontend e o backend da aplicação
- [ ] Abrir URL `http://localhost:3000/cms/topics`
- [ ] Clicar nos três pontinhos do header e ecolher uma forma de ordenação
- [ ] Verificar a ordenação `do maior para o menor`
- [ ] - [ ] Verificar a ordenação `do menor  para o maior`
- [ ] Aplicação não deve conter nenhum erro, warning ou console.log
- [ ] Alteração proposta no card foi implementada
