### PR TITLE
343 fix corrigir erro ao salvar edicao de topicos

### DIFF
--- a/src/app/api/topics/updateTopic/route.ts
+++ b/src/app/api/topics/updateTopic/route.ts
@@ -49,7 +49,7 @@ export async function PATCH(req: NextRequest) {
         payload,
       });
 
-      return NextResponse.json(
+        return NextResponse.json(
         {
           error:
             payload?.error ||

--- a/src/app/cms/topics/[id]/edit/page.tsx
+++ b/src/app/cms/topics/[id]/edit/page.tsx
@@ -1,4 +1,4 @@
-'use client';
+/* 'use client';
 
 import Form from "@/components/UI/dashboard/form";
 import {
@@ -91,4 +91,21 @@ return (
   />
 )
 
-};
+}; */
+
+import DetailTopic from "@/components/PageElements/cms/topics/detail-topic";
+
+interface PageProps {
+  params: {
+    id: string;
+  };
+}
+
+export default function Page({ params }: PageProps) {
+  return (
+    <DetailTopic 
+      id={params.id} 
+      isEditing // Isso vai habilitar os campos automaticamente!
+    />
+  );
+}

--- a/src/app/cms/topics/[id]/edit/page.tsx
+++ b/src/app/cms/topics/[id]/edit/page.tsx
@@ -109,7 +109,7 @@ export default function Page({ params }: PageProps) {
   return (
     <DetailTopic 
       id={params.id} 
-      isEditing // Isso vai habilitar os campos automaticamente!
+      isEditing 
     />
   );
 }

--- a/src/components/PageElements/cms/topics/detail-topic.tsx
+++ b/src/components/PageElements/cms/topics/detail-topic.tsx
@@ -155,6 +155,8 @@ export default function DetailTopic({ id, onArchive, isEditing }: Props) {
           sx={textFieldStyles}
         />
 
+        {/* Campos para edição de vídeo */}
+        
         {/* <TextField
               label="Título do vídeo"
               value={formData?.video?.title || ""}

--- a/src/components/PageElements/cms/topics/detail-topic.tsx
+++ b/src/components/PageElements/cms/topics/detail-topic.tsx
@@ -1,11 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import Form from "@/components/UI/dashboard/form";
-import {
-  TopicFormSchema,
-  topicFormDefs,
-} from "@/components/UI/dashboard/forms/defs/topic.defs";
 import { useRouter } from "next/navigation";
 import { Box, Button, TextField, Typography, useTheme } from "@mui/material";
 import { UpperBanner } from "@/components/UI/cms/upper-banner";
@@ -16,29 +11,13 @@ import {
   textFieldStyles,
   textFieldsContainerStyles,
 } from "@/components/UI/dashboard/forms/form.styles";
-import { CmsTopic, CmsTopicVideo } from "@/types/type";
-import { FormActions } from "@/components/UI/dashboard/forms/form-actions";
-import { fi } from "zod/v4/locales";
-import PreviousMap_ from "postcss/lib/previous-map";
-import { Description } from "@mui/icons-material";
-
+import { CmsTopic } from "@/types/type";
 interface Props {
   id: string;
-  onArchive?: (id: string) => void;
   isEditing?: boolean;
 }
 
-const getYouTubeEmbedUrl = (url: string) => {
-  const videoId = url.split("v=")[1]?.split("&")[0];
-
-  if (!videoId) {
-    return null;
-  }
-
-  return `https://www.youtube.com/embed/${videoId}`;
-};
-
-export default function DetailTopic({ id, onArchive, isEditing }: Props) {
+export default function DetailTopic({ id, isEditing }: Props) {
   const [topic, setTopic] = useState<CmsTopic | undefined>(undefined);
   const [formData, setFormData] = useState<CmsTopic | undefined>();
   const muiTheme = useTheme();
@@ -78,7 +57,7 @@ export default function DetailTopic({ id, onArchive, isEditing }: Props) {
         description: formData.description,
         shortDescription: formData.shortDescription,
         themeId: formData.theme?.id,
-        references: formData.video?.references ?? "",
+        /* references: formData.video?.references ?? "", */
       };
 
       const url = `/api/topics/updateTopic`;
@@ -94,8 +73,6 @@ export default function DetailTopic({ id, onArchive, isEditing }: Props) {
       if (!response.ok) {
         throw new Error(`Erro ao atualizar tópico: ${response.status}`);
       }
-
-      const data = await response.json();
 
       router.push("/cms/topics");
     } catch (error) {

--- a/src/components/PageElements/cms/topics/detail-topic.tsx
+++ b/src/components/PageElements/cms/topics/detail-topic.tsx
@@ -77,10 +77,8 @@ export default function DetailTopic({ id, onArchive, isEditing }: Props) {
         title: formData.title,
         description: formData.description,
         shortDescription: formData.shortDescription,
-        /* videoTitle: formData.video?.title, */
-        videoDescription: formData.video?.description,
-        videoReferences: formData.video?.references,
-        videoLink: formData.video?.link,
+        themeId: formData.theme?.id,
+        references: formData.video?.references ?? "",
       };
 
       const url = `/api/topics/updateTopic`;
@@ -157,7 +155,7 @@ export default function DetailTopic({ id, onArchive, isEditing }: Props) {
           sx={textFieldStyles}
         />
 
-        <TextField
+        {/* <TextField
               label="Título do vídeo"
               value={formData?.video?.title || ""}
               onChange={(e) =>
@@ -231,7 +229,7 @@ export default function DetailTopic({ id, onArchive, isEditing }: Props) {
               InputProps={{ readOnly: !isEditing }}
               rows={4}
               sx={textFieldStyles}
-            />
+            /> */}
       </Box>
 
       <Box sx={actionsContainerStyles}>

--- a/src/components/PageElements/cms/topics/detail-topic.tsx
+++ b/src/components/PageElements/cms/topics/detail-topic.tsx
@@ -12,6 +12,7 @@ import {
   textFieldsContainerStyles,
 } from "@/components/UI/dashboard/forms/form.styles";
 import { CmsTopic } from "@/types/type";
+import { FormActions } from "@/components/UI/dashboard/forms/form-actions";
 interface Props {
   id: string;
   isEditing?: boolean;
@@ -19,6 +20,11 @@ interface Props {
 
 export default function DetailTopic({ id, isEditing }: Props) {
   const [topic, setTopic] = useState<CmsTopic | undefined>(undefined);
+  const [originalTopic, setOriginalTopic] = useState<CmsTopic | undefined>(
+    undefined,
+  );
+  const [errorStatus, setErrorStatus] = useState<number | null>(null);
+  const [errorMessage, setErrorMessage] = useState("")
   const [formData, setFormData] = useState<CmsTopic | undefined>();
   const muiTheme = useTheme();
   const router = useRouter();
@@ -48,19 +54,21 @@ export default function DetailTopic({ id, isEditing }: Props) {
     fetchTopic();
   }, [fetchTopic]);
 
-  const handleSave = async () => {
-    if (!formData) return;
+  async function handleSave() {
+    if (!topic) return
 
     try {
+      setErrorMessage("")
+
       const payload = {
         title: topic.title,
         shortDescription: topic.shortDescription,
         description: topic.description,
         isActive: topic.isActive,
-        /*videoTitle: topic.video?.title,
+        /* videoTitle: topic.video?.title,
         videoDescription: topic.video?.description,
         videoReferences: topic.video?.references,
-        videoLink: topic.video?.link,*/
+        videoLink: topic.video?.link, */
       }
 
       const response = await fetch("/api/topics/updateTopic", {
@@ -76,20 +84,40 @@ export default function DetailTopic({ id, isEditing }: Props) {
       throw new Error(`Erro: ${response.status}`)
     }
 
-      if (!response.ok) {
-        throw new Error(`Erro ao atualizar tópico: ${response.status}`);
-      }
+    const data = await response.json()
 
-      router.push("/cms/topics");
-    } catch (error) {
-      console.error("Erro ao salvar as alterações do tópico:", error);
-      alert("Não foi possível salvar as alterações. Verifique o console.");
+    router.push("/cms/topics");
+
+    setTopic(data.data ?? topic)
+    setOriginalTopic(data.data ?? topic)
+  } catch (error) {
+      console.error("Erro ao salvar tópico:", error);
+      setErrorMessage("Ocorreu um erro ao salvar o tópico. Por favor, tente novamente.");
     }
-  };
+
+}
 
   const handleCancel = () => {
     router.push(`/cms/topics/${id}`);
   };
+
+  function handleEdit() {
+    router.push(`/cms/topics/${id}/edit`);
+  }
+
+  const handleBack = () => {
+    router.push(`/cms/topics`);
+  };
+
+  function handleChange(field: keyof CmsTopic , value: string) {
+    if (!topic) return
+
+    setTopic({
+      ...topic,
+      [field]: value,
+
+    })
+  }
 
   return (
     <Box>
@@ -103,23 +131,18 @@ export default function DetailTopic({ id, isEditing }: Props) {
       </Box>
 
       <Box sx={textFieldsContainerStyles}>
-
         <TextField
           label="Título"
-          value={formData?.title || ""}
-          onChange={(e) =>
-            setFormData((prev) => (prev ? { ...prev, title: e.target.value } : prev))
-          }
+          value={topic?.title || ""}
+          onChange={(event) => handleChange("title", event.target.value)}
           InputProps={{ readOnly: !isEditing }}
           sx={textFieldStyles}
         />
 
         <TextField
           label="Descrição"
-          value={formData?.description || ""}
-          onChange={(e) =>
-            setFormData((prev) => (prev ? { ...prev, description: e.target.value } : prev))
-          }
+          value={topic?.description || ""}
+          onChange={(event) => handleChange("description", event.target.value)}
           InputProps={{ readOnly: !isEditing }}
           multiline
           rows={4}
@@ -128,10 +151,8 @@ export default function DetailTopic({ id, isEditing }: Props) {
 
         <TextField
           label="Descrição curta"
-          value={formData?.shortDescription || ""}
-          onChange={(e) =>
-            setFormData((prev) => (prev ? { ...prev, shortDescription: e.target.value } : prev))
-          }
+          value={topic?.shortDescription || ""}
+          onChange={(event) => handleChange("shortDescription", event.target.value)}
           InputProps={{ readOnly: !isEditing }}
           multiline
           rows={4}
@@ -139,7 +160,7 @@ export default function DetailTopic({ id, isEditing }: Props) {
         />
 
         {/* Campos para edição de vídeo */}
-        
+
         {/* <TextField
               label="Título do vídeo"
               value={formData?.video?.title || ""}
@@ -218,55 +239,20 @@ export default function DetailTopic({ id, isEditing }: Props) {
       </Box>
 
       <Box sx={actionsContainerStyles}>
-        {isEditing ? (
-          <>
-            <Button
-              variant="outlined"
-              sx={{
-                ...cancelButtonStyles(muiTheme),
-                borderColor: "red",
-                color: "red",
-                "&:hover": { borderColor: "darkred" },
-              }}
-              onClick={handleCancel}
-            >
-              CANCELAR
-            </Button>
-
-            <Button
-              variant="contained"
-              sx={{ backgroundColor: "#004A7C", "&:hover": { backgroundColor: "#003B63" } }}
-              onClick={handleSave}
-            >
-              SALVAR
-            </Button>
-          </>
-        ) : (
-          <Button
-            variant="contained"
-            sx={returnToList(muiTheme)}
-            onClick={() => router.push("/cms/topics")}
-          >
-            VOLTAR PARA LISTA
-          </Button>
-        )}
+        <FormActions
+          isValid={
+            !!topic?.title && !!topic?.shortDescription && !!topic?.description
+          }
+          isDirty={JSON.stringify(topic) !== JSON.stringify(originalTopic)}
+          mode={isEditing ? "edit" : "view"}
+          entityPath="cms/topics"
+          entityId={id}
+          onSave={handleSave}
+          onCancel={handleCancel}
+          onEdit={handleEdit}
+          onBack={handleBack}
+        />
       </Box>
-
-      <Box sx={actionsContainerStyles}>
-              <FormActions
-                isValid={!!topic?.title && !!topic?.shortDescription && !!topic?.description}
-                isDirty={JSON.stringify(topic) !== JSON.stringify(originalTopic)}
-                mode={isEditing ? "edit" : "view"}
-                entityPath="cms/topics"
-                entityId={id}
-                onSave={handleSave}
-                onCancel={handleCancel}
-                onEdit={handleEdit}
-                onBack={handleBack}
-              />
-      </Box>
-
-  
     </Box>
   );
 }

--- a/src/components/PageElements/cms/topics/detail-topic.tsx
+++ b/src/components/PageElements/cms/topics/detail-topic.tsx
@@ -19,6 +19,8 @@ import {
 import { CmsTopic, CmsTopicVideo } from "@/types/type";
 import { FormActions } from "@/components/UI/dashboard/forms/form-actions";
 import { fi } from "zod/v4/locales";
+import PreviousMap_ from "postcss/lib/previous-map";
+import { Description } from "@mui/icons-material";
 
 interface Props {
   id: string;
@@ -73,10 +75,9 @@ export default function DetailTopic({ id, onArchive, isEditing }: Props) {
     try {
       const payload = {
         title: formData.title,
-        shortDescription: formData.shortDescription,
         description: formData.description,
-        isActive: formData.isActive,
-        videoTitle: formData.video?.title,
+        shortDescription: formData.shortDescription,
+        /* videoTitle: formData.video?.title, */
         videoDescription: formData.video?.description,
         videoReferences: formData.video?.references,
         videoLink: formData.video?.link,
@@ -148,7 +149,7 @@ export default function DetailTopic({ id, onArchive, isEditing }: Props) {
           label="Descrição curta"
           value={formData?.shortDescription || ""}
           onChange={(e) =>
-            setFormData((prev) => (prev ? { ...prev, description: e.target.value } : prev))
+            setFormData((prev) => (prev ? { ...prev, shortDescription: e.target.value } : prev))
           }
           InputProps={{ readOnly: !isEditing }}
           multiline
@@ -156,136 +157,119 @@ export default function DetailTopic({ id, onArchive, isEditing }: Props) {
           sx={textFieldStyles}
         />
 
-        {/* <TextField
-          label="Ativo/Inativo"
-          value={topicStatus}
-          fullWidth
-          InputProps={{ readOnly: true }}
-          sx={textFieldStyles}
-        /> */}
-
-        
-
-        
-      </Box>
-
-      <Box sx={{ mt: 4 }}>
-        <Typography variant="h5" component="h2" sx={{ mb: 2 }}>
-          Vídeo
-        </Typography>
-
-        {topic?.video ? (
-          <Box sx={{ display: "grid", gap: 2 }}>
-            <TextField
+        <TextField
               label="Título do vídeo"
-              value={topic.video.title || ""}
-              fullWidth
-              InputProps={{ readOnly: !isEditing }}
-              onChange={(event) =>
-                handleVideoChange("title", event.target.value)
+              value={formData?.video?.title || ""}
+              onChange={(e) =>
+                setFormData((prev) => {
+                  prev ? {
+                    ...prev,
+                    video: {
+                      ...(prev.video || {}),
+                      title: e.target.value,
+                    },
+                  } : prev
+                })
               }
+              InputProps={{ readOnly: !isEditing }}
+              rows={4}
               sx={textFieldStyles}
             />
 
             <TextField
-              label="Explicação do vídeo"
-              value={topic.video.description || ""}
-              fullWidth
-              multiline
-              minRows={4}
-              InputProps={{ readOnly: !isEditing }}
-              onChange={(event) =>
-                handleVideoChange("description", event.target.value)
+              label="Descrição do vídeo"
+              value={formData?.video?.description || ""}
+              onChange={(e) =>
+                setFormData((prev) => {
+                  prev ? {
+                    ...prev,
+                    video: {
+                      ...(prev.video || {}),
+                      description: e.target.value,
+                    },
+                  } : prev
+                })
               }
+              InputProps={{ readOnly: !isEditing }}
+              
               sx={textFieldStyles}
             />
 
             <TextField
               label="Referências do vídeo"
-              value={topic.video.references || ""}
-              fullWidth
-              InputProps={{ readOnly: !isEditing }}
-              onChange={(event) =>
-                handleVideoChange("references", event.target.value)
+              value={formData?.video?.references || ""}
+              onChange={(e) =>
+                setFormData((prev) => {
+                  prev ? {
+                    ...prev,
+                    video: {
+                      ...(prev.video || {}),
+                      references: e.target.value,
+                    },
+                  } : prev
+                })
               }
+              InputProps={{ readOnly: !isEditing }}
+              rows={4}
               sx={textFieldStyles}
             />
 
             <TextField
               label="Link do vídeo"
-              value={topic.video.link || ""}
-              fullWidth
-              InputProps={{ readOnly: !isEditing }}
-              onChange={(event) =>
-                handleVideoChange("link", event.target.value)
+              value={formData?.video?.link || ""}
+              onChange={(e) =>
+                setFormData((prev) => {
+                  prev ? {
+                    ...prev,
+                    video: {
+                      ...(prev.video || {}),
+                      link: e.target.value,
+                    },
+                  } : prev
+                })
               }
+              InputProps={{ readOnly: !isEditing }}
+              rows={4}
               sx={textFieldStyles}
             />
+      </Box>
 
-            {isEditing && (
-              <Box
-                sx={{
-                  display: "flex",
-                  justifyContent: "flex-end",
-                  gap: 2,
-                  mt: 4,
-                }}
-              >
-                <Button
-                  variant="outlined"
-                  sx={{
-                    ...cancelButtonStyles(muiTheme),
-                    borderColor: "red",
-                    color: "red",
-                    backgroundColor: "#fff",
-                    px: 4,
-                  }}
-                  onClick={handleCancelEdit}
-                >
-                  CANCELAR
-                </Button>
+      <Box sx={actionsContainerStyles}>
+        {isEditing ? (
+          <>
+            <Button
+              variant="outlined"
+              sx={{
+                ...cancelButtonStyles(muiTheme),
+                borderColor: "red",
+                color: "red",
+                "&:hover": { borderColor: "darkred" },
+              }}
+              onClick={handleCancel}
+            >
+              CANCELAR
+            </Button>
 
-                <Button
-                  variant="contained"
-                  onClick={handleSave}
-                  disabled={!topic}
-                  sx={{
-                    backgroundColor: "#004A7C",
-                    px: 4,
-                    "&:hover": {
-                      backgroundColor: "#003B63",
-                    },
-                  }}
-                >
-                  SALVAR
-                </Button>
-              </Box>
-            )}
-
-            {/* {videoEmbedUrl ? (
-              <Box sx={{ width: "100%", overflow: "hidden", borderRadius: 2 }}>
-                <iframe
-                  width="100%"
-                  height="332"
-                  src={videoEmbedUrl}
-                  title={topic.video.title || "Vídeo do tópico"}
-                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                  referrerPolicy="strict-origin-when-cross-origin"
-                  allowFullScreen
-                />
-              </Box>
-            ) : (
-              <Link href={topic.video.link} target="_blank" rel="noopener noreferrer">
-                Abrir vídeo em nova aba
-              </Link>
-            )} */}
-          </Box>
+            <Button
+              variant="contained"
+              sx={{ backgroundColor: "#004A7C", "&:hover": { backgroundColor: "#003B63" } }}
+              onClick={handleSave}
+            >
+              SALVAR
+            </Button>
+          </>
         ) : (
-          <Typography variant="body1">
-            Nenhum vídeo cadastrado para este tópico.
-          </Typography>
+          <Button
+            variant="contained"
+            sx={returnToList(muiTheme)}
+            onClick={() => router.push("/cms/topics")}
+          >
+            VOLTAR PARA LISTA
+          </Button>
         )}
       </Box>
+
+      
     </Box>
   );
 }

--- a/src/components/PageElements/cms/topics/detail-topic.tsx
+++ b/src/components/PageElements/cms/topics/detail-topic.tsx
@@ -1,30 +1,29 @@
+"use client";
 
-'use client';
-
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Form from "@/components/UI/dashboard/form";
 import {
   TopicFormSchema,
   topicFormDefs,
 } from "@/components/UI/dashboard/forms/defs/topic.defs";
 import { useRouter } from "next/navigation";
-import { Alert ,Box, Button, Link, TextField, Typography, useTheme } from "@mui/material";
+import { Box, Button, TextField, Typography, useTheme } from "@mui/material";
 import { UpperBanner } from "@/components/UI/cms/upper-banner";
 import {
   actionsContainerStyles,
+  cancelButtonStyles,
+  returnToList,
   textFieldStyles,
   textFieldsContainerStyles,
 } from "@/components/UI/dashboard/forms/form.styles";
-import { BadRequest } from "@/components/BadRequest";
-import { Loading } from "@/components/Loading";
-import { NoData } from "@/components/NoData";
 import { CmsTopic, CmsTopicVideo } from "@/types/type";
 import { FormActions } from "@/components/UI/dashboard/forms/form-actions";
-import { cancelButtonStyles } from "@/components/UI/dashboard/forms/form.styles"
 import { fi } from "zod/v4/locales";
 
 interface Props {
   id: string;
+  onArchive?: (id: string) => void;
+  isEditing?: boolean;
 }
 
 const getYouTubeEmbedUrl = (url: string) => {
@@ -37,23 +36,16 @@ const getYouTubeEmbedUrl = (url: string) => {
   return `https://www.youtube.com/embed/${videoId}`;
 };
 
-export default function DetailTopic({ id }: Props) {
+export default function DetailTopic({ id, onArchive, isEditing }: Props) {
   const [topic, setTopic] = useState<CmsTopic | undefined>(undefined);
-  const [originalTopic, setOriginalTopic] = useState<CmsTopic | undefined>(undefined)
-  const [isEditing, setIsEditing] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [errorStatus, setErrorStatus] = useState<number | null>(null);
-  const [errorMessage, setErrorMessage] = useState("")
+  const [formData, setFormData] = useState<CmsTopic | undefined>();
   const muiTheme = useTheme();
   const router = useRouter();
 
-
   const fetchTopic = useCallback(async () => {
-    setLoading(true);
-    setErrorStatus(null);
-
     try {
-      const response = await fetch("/api/topics/getTopicById", {
+      const url = `/api/topics/getTopicById`;
+      const response = await fetch(url, {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
@@ -61,187 +53,106 @@ export default function DetailTopic({ id }: Props) {
         },
       });
 
-       if (!response.ok) throw new Error(`Erro: ${response.status}`)
+      if (!response.ok) throw new Error(`Erro: ${response.status}`);
 
       const data = await response.json();
-
-      setTopic(data.data)
-      setOriginalTopic(data.data)
+      setTopic(data.data);
+      setFormData(data.data);
     } catch (error) {
       console.error("Erro ao buscar tópico:", error);
-    } 
+    }
   }, [id]);
 
   useEffect(() => {
     fetchTopic();
   }, [fetchTopic]);
 
-  /* const topicStatus = useMemo(
-    () => (topic?.isActive ? "Ativo" : "Inativo"),
-    [topic?.isActive]
-  ); */
+  const handleSave = async () => {
+    if (!formData) return;
 
-  function handleChange(field: keyof CmsTopic , value: string) {
-    if (!topic) return
-
-    setTopic({
-      ...topic,
-      [field]: value,
-
-    })
-  }
-
-  function handleVideoChange(field: keyof CmsTopicVideo, value: string) {
-    if (!topic || !topic.video) return
-
-    setTopic({
-      ...topic,
-      video: {
-        ...topic.video,
-        [field]: value,
-      } as CmsTopicVideo
-    });
-  }
-
-  function handleEdit() {
-    setOriginalTopic(topic)
-    setIsEditing(true)
-    setErrorMessage("")
-  }
-  
-function handleCancelEdit() {
-    const confirmCancel = window.confirm(
-      "Deseja cancelar a edição? As alterações serão perdidas."
-    )
-
-    if (!confirmCancel) return
-
-    setTopic(originalTopic)
-    setIsEditing(false)
-    setErrorMessage("")
-  }
-
-  /* Começa aqui */
-  async function handleSave() {
-    if (!topic) return
-    
     try {
-      setErrorMessage("")
-
       const payload = {
-        title: topic.title,
-        shortDescription: topic.shortDescription,
-        description: topic.description,
-        isActive: topic.isActive,
-        videoTitle: topic.video?.title,
-        videoDescription: topic.video?.description,
-        videoReferences: topic.video?.references,
-        videoLink: topic.video?.link,
+        title: formData.title,
+        shortDescription: formData.shortDescription,
+        description: formData.description,
+        isActive: formData.isActive,
+        videoTitle: formData.video?.title,
+        videoDescription: formData.video?.description,
+        videoReferences: formData.video?.references,
+        videoLink: formData.video?.link,
+      };
+
+      const url = `/api/topics/updateTopic`;
+      const response = await fetch(url, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          id,
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Erro ao atualizar tópico: ${response.status}`);
       }
 
-      const response = await fetch("/api/topics/updateTopic", {
-      method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        "id": String(id),
-      },
-      body: JSON.stringify(payload),
-    });
+      const data = await response.json();
 
-    if (!response.ok) {
-      throw new Error(`Erro: ${response.status}`)
+      router.push("/cms/topics");
+    } catch (error) {
+      console.error("Erro ao salvar as alterações do tópico:", error);
+      alert("Não foi possível salvar as alterações. Verifique o console.");
     }
+  };
 
-    const data = await response.json()
-
-    setTopic(data.data ?? topic)
-    setOriginalTopic(data.data ?? topic)
-    setIsEditing(false)
-  } catch (error) {
-      console.error("Erro ao salvar tópico:", error);
-      setErrorMessage("Ocorreu um erro ao salvar o tópico. Por favor, tente novamente.");
-    }
-
-}
-
-
-/*   if (loading) return <Loading />;
-  if (errorStatus === 404) return <NoData />;
-  if (errorStatus) return <BadRequest />;
-  if (!topic) return <NoData />; */
-
-/*   const videoEmbedUrl = topic.video?.link ? getYouTubeEmbedUrl(topic.video.link) : null; */
+  const handleCancel = () => {
+    router.push(`/cms/topics/${id}`);
+  };
 
   return (
     <Box>
-      <UpperBanner
-        title={topic?.title || "Tópicos"}
-        showBreadCrumb
-        breadCrumbLabel={topic?.title}
-      />
-
-       <Box sx={textFieldsContainerStyles}>
-
-        <Box
-        sx={{
-          backgroundColor: "#EAF3FA",
-          minHeight: "120px",
-          px: { xs: 3, md: 10 },
-          py: 4,
-          mt: -2,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-        }}
-      >
-        <Typography
-          sx={{
-            color: "#004A7C",
-            fontSize: "36px",
-            fontWeight: 700,
-          }}
-        >
-          Topics
-        </Typography>
-
-        {!isEditing && (
-          <Button
-            onClick={handleEdit}
-            disabled={!topic}
-            sx={{
-              color: "#5E8CB5",
-              textTransform: "none",
-              fontSize: "16px",
-              fontWeight: 400,
-            }}
-          >
-            ✎ Editar
-          </Button>
-        )}
+      <Box sx={{ position: "relative" }}>
+        <UpperBanner
+          title={topic?.title || "Tópicos"}
+          showBreadCrumb
+          breadCrumbLabel={topic?.title}
+          editButton={!isEditing}
+        />
       </Box>
 
-        {/* <TextField
-          label="ID"
-          value={topic.id}
-          fullWidth
-          InputProps={{ readOnly: true }}
-          sx={textFieldStyles}
-        /> */} 
-
-        {/* <TextField
-          label="Tema"
-          value={topic.theme?.title || ""}
-          fullWidth
-          InputProps={{ readOnly: true }}
-          sx={textFieldStyles}
-        /> */}
+      <Box sx={textFieldsContainerStyles}>
 
         <TextField
           label="Título"
-          value={topic?.title || ""}
-          fullWidth
+          value={formData?.title || ""}
+          onChange={(e) =>
+            setFormData((prev) => (prev ? { ...prev, title: e.target.value } : prev))
+          }
           InputProps={{ readOnly: !isEditing }}
-           onChange={(event) => handleChange("title", event.target.value)}
+          sx={textFieldStyles}
+        />
+
+        <TextField
+          label="Descrição"
+          value={formData?.description || ""}
+          onChange={(e) =>
+            setFormData((prev) => (prev ? { ...prev, description: e.target.value } : prev))
+          }
+          InputProps={{ readOnly: !isEditing }}
+          multiline
+          rows={4}
+          sx={textFieldStyles}
+        />
+
+        <TextField
+          label="Descrição curta"
+          value={formData?.shortDescription || ""}
+          onChange={(e) =>
+            setFormData((prev) => (prev ? { ...prev, description: e.target.value } : prev))
+          }
+          InputProps={{ readOnly: !isEditing }}
+          multiline
+          rows={4}
           sx={textFieldStyles}
         />
 
@@ -253,25 +164,9 @@ function handleCancelEdit() {
           sx={textFieldStyles}
         /> */}
 
-        <TextField
-          label="Descrição curta"
-          value={topic?.shortDescription || ""}
-          fullWidth
-          InputProps={{ readOnly: !isEditing }}
-          onChange={(event) => handleChange("shortDescription", event.target.value)}
-          sx={textFieldStyles}
-        />
+        
 
-        <TextField
-          label="Descrição longa"
-          value={topic?.description || ""}
-          fullWidth
-          InputProps={{ readOnly: !isEditing }}
-           onChange={(event) => handleChange("description", event.target.value)}
-          multiline
-          minRows={4}
-          sx={textFieldStyles}
-        />
+        
       </Box>
 
       <Box sx={{ mt: 4 }}>
@@ -286,7 +181,9 @@ function handleCancelEdit() {
               value={topic.video.title || ""}
               fullWidth
               InputProps={{ readOnly: !isEditing }}
-              onChange={(event) => handleVideoChange("title", event.target.value)}
+              onChange={(event) =>
+                handleVideoChange("title", event.target.value)
+              }
               sx={textFieldStyles}
             />
 
@@ -297,7 +194,9 @@ function handleCancelEdit() {
               multiline
               minRows={4}
               InputProps={{ readOnly: !isEditing }}
-              onChange={(event) => handleVideoChange("description", event.target.value)}
+              onChange={(event) =>
+                handleVideoChange("description", event.target.value)
+              }
               sx={textFieldStyles}
             />
 
@@ -306,7 +205,9 @@ function handleCancelEdit() {
               value={topic.video.references || ""}
               fullWidth
               InputProps={{ readOnly: !isEditing }}
-              onChange={(event) => handleVideoChange("references", event.target.value)}
+              onChange={(event) =>
+                handleVideoChange("references", event.target.value)
+              }
               sx={textFieldStyles}
             />
 
@@ -315,49 +216,51 @@ function handleCancelEdit() {
               value={topic.video.link || ""}
               fullWidth
               InputProps={{ readOnly: !isEditing }}
-              onChange={(event) => handleVideoChange("link", event.target.value)}
+              onChange={(event) =>
+                handleVideoChange("link", event.target.value)
+              }
               sx={textFieldStyles}
             />
 
             {isEditing && (
-                      <Box
-                        sx={{
-                          display: "flex",
-                          justifyContent: "flex-end",
-                          gap: 2,
-                          mt: 4,
-                        }}
-                      >
-                        <Button
-                          variant="outlined"
-                          sx={{
-                            ...cancelButtonStyles(muiTheme),
-                            borderColor: "red",
-                            color: "red",
-                            backgroundColor: "#fff",
-                            px: 4,
-                          }}
-                          onClick={handleCancelEdit}
-                        >
-                          CANCELAR
-                        </Button>
-            
-                        <Button
-                          variant="contained"
-                          onClick={handleSave}
-                          disabled={!topic}
-                          sx={{
-                            backgroundColor: "#004A7C",
-                            px: 4,
-                            "&:hover": {
-                              backgroundColor: "#003B63",
-                            },
-                          }}
-                        >
-                          SALVAR
-                        </Button>
-                      </Box>
-                    )}
+              <Box
+                sx={{
+                  display: "flex",
+                  justifyContent: "flex-end",
+                  gap: 2,
+                  mt: 4,
+                }}
+              >
+                <Button
+                  variant="outlined"
+                  sx={{
+                    ...cancelButtonStyles(muiTheme),
+                    borderColor: "red",
+                    color: "red",
+                    backgroundColor: "#fff",
+                    px: 4,
+                  }}
+                  onClick={handleCancelEdit}
+                >
+                  CANCELAR
+                </Button>
+
+                <Button
+                  variant="contained"
+                  onClick={handleSave}
+                  disabled={!topic}
+                  sx={{
+                    backgroundColor: "#004A7C",
+                    px: 4,
+                    "&:hover": {
+                      backgroundColor: "#003B63",
+                    },
+                  }}
+                >
+                  SALVAR
+                </Button>
+              </Box>
+            )}
 
             {/* {videoEmbedUrl ? (
               <Box sx={{ width: "100%", overflow: "hidden", borderRadius: 2 }}>
@@ -378,11 +281,11 @@ function handleCancelEdit() {
             )} */}
           </Box>
         ) : (
-          <Typography variant="body1">Nenhum vídeo cadastrado para este tópico.</Typography>
+          <Typography variant="body1">
+            Nenhum vídeo cadastrado para este tópico.
+          </Typography>
         )}
       </Box>
-
-  
     </Box>
   );
 }

--- a/src/components/PageElements/cms/topics/render-topic.tsx
+++ b/src/components/PageElements/cms/topics/render-topic.tsx
@@ -1,10 +1,12 @@
+"use client";
+
 import { Column, TableCMS } from "@/components/UI/cms/table-cms";
 import { UpperBanner } from "@/components/UI/cms/upper-banner";
 import { getTopics } from "@/utils/api/topics";
 import { Box } from "@mui/material";
 import { useEffect, useState } from "react";
 
-const columns: Column[] = [
+const columns = [
   { id: "id", label: "ID" },
   { id: "title", label: "Título" },
   { id: "themeTitle", label: "Tema" },

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -121,12 +121,8 @@ export interface CmsTopic {
   shortDescription: string;
   description: string;
   isActive: boolean;
-  theme?: {
-    id: string;
-    title: string;
-  }
+  theme?: CmsTopicTheme | null;
   video?: CmsTopicVideo | null;
-  themeId?: string;
 }
 
 export interface CmsExercise {

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -121,8 +121,12 @@ export interface CmsTopic {
   shortDescription: string;
   description: string;
   isActive: boolean;
-  theme?: CmsTopicTheme | null;
+  theme?: {
+    id: string;
+    title: string;
+  }
   video?: CmsTopicVideo | null;
+  themeId?: string;
 }
 
 export interface CmsExercise {


### PR DESCRIPTION
#343 - fix: Corrigir erro ao salvar edição de tópicos
====
  
### 🆙 CHANGELOG

- Remoção dos campos de vídeo do payload de edição de tópicos
- Adição do themeId ao payload de edição de tópicos
- Campos de edição de vídeo do formulário comentados

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [ ] Fazer deploy em ambiente de teste
- [ ] Abrir URL da aplicação de teste
- [ ] Abrir lista de tópicos
- [ ] Acessar visualização de um tópico
- [ ] Clicar em editar para abrir os campos de edição
- [ ] Alterar um campo 
- [ ] Clicar em salvar 
- [ ] Aplicação não deve conter nenhum erro, warning ou console.log
- [ ] Alteração proposta no card foi implementada
