### PR TITLE
345 corrigir estilo visualizar temas

### DIFF
--- a/src/app/cms/themes/[id]/edit/page.tsx
+++ b/src/app/cms/themes/[id]/edit/page.tsx
@@ -3,10 +3,11 @@ import DetailTheme from "@/components/PageElements/cms/themes/detail-theme";
 interface PageProps {
   params: {
     id: string;
+  
   };
 }
 
-export default function Page({ params }: { params: { id: string } }) {
+export default function Page({ params }: PageProps) {
   return (
     <DetailTheme
     id={params.id}

--- a/src/app/cms/themes/[id]/edit/page.tsx
+++ b/src/app/cms/themes/[id]/edit/page.tsx
@@ -1,0 +1,15 @@
+import DetailTheme from "@/components/PageElements/cms/themes/detail-theme";
+
+interface PageProps {
+  params: {
+    id: string;
+  };
+}
+
+export default function Page({ params }: { params: { id: string } }) {
+  return (
+    <DetailTheme
+    id={params.id}
+    isEditing 
+    />)
+}

--- a/src/app/cms/topics/[id]/edit/page.tsx
+++ b/src/app/cms/topics/[id]/edit/page.tsx
@@ -1,4 +1,4 @@
-'use client';
+/*'use client';
 
 import Form from "@/components/UI/dashboard/form";
 import {
@@ -77,18 +77,38 @@ export default function EditTopicPage({ params }: Props) {
 
 
 return (
-  <Form
-    title="Editar Tópico"
-    onSubmit={handleSubmit}
-    schema={TopicFormSchema}
-    formDefs={{
-      ...topicFormDefs,
-      defaultValues: topic,
-    }}
-    mode="edit"
-    entityPath="/api/topics"
-    entityId={params.id}
-  />
+  <>
+    
+    <Form
+      title="Editar Tópico"
+      onSubmit={handleSubmit}
+      schema={TopicFormSchema}
+      formDefs={{
+        ...topicFormDefs,
+        defaultValues: topic,
+      }}
+      mode="edit"
+      entityPath="/api/topics"
+      entityId={params.id}
+      
+    />
+  </>
 )
 
-};
+};*/
+
+import DetailTopic from "@/components/PageElements/cms/topics/detail-topic";
+
+interface PageProps {
+  params: {
+    id: string;
+  };
+}
+
+export default function Page({ params }: { params: { id: string } }) {
+  return (
+    <DetailTopic
+    id={params.id}
+    isEditing 
+    />)
+}

--- a/src/components/PageElements/cms/exercises/detail-exercise.tsx
+++ b/src/components/PageElements/cms/exercises/detail-exercise.tsx
@@ -94,7 +94,7 @@ export default function DetailExercise({ id, onArchive, isEditing }: Props) {
   };
 
   const handleEdit = () => {
-    /*router.push(`/cms/exercises/${id}/edit`);*/
+    router.push(`/cms/exercises/${id}/edit`);
     
   }
 

--- a/src/components/PageElements/cms/exercises/detail-exercise.tsx
+++ b/src/components/PageElements/cms/exercises/detail-exercise.tsx
@@ -6,6 +6,7 @@ import { Box, Button, TextField, useTheme } from "@mui/material";
 import { UpperBanner } from "@/components/UI/cms/upper-banner";
 import { actionsContainerStyles, cancelButtonStyles, returnToList, textFieldStyles, textFieldsContainerStyles } from "@/components/UI/dashboard/forms/form.styles";
 import { CmsExercise } from "@/types/type";
+import { FormActions } from "@/components/UI/dashboard/forms/form-actions";
 
 interface Props {
   id: string;
@@ -81,9 +82,25 @@ export default function DetailExercise({ id, onArchive, isEditing }: Props) {
       alert("Não foi possível salvar as alterações. Verifique o console.");
     }
   };
+  
   const handleCancel = () => {
     router.push(`/cms/exercises/${id}`);
+    const confirmCancel = window.confirm(
+      "Deseja cancelar a edição? As alterações serão perdidas."
+    );
+    if (!confirmCancel) {
+      return;
+    }
   };
+
+  const handleEdit = () => {
+    router.push(`/cms/exercises/${id}/edit`);
+  }
+
+  const handleBack = () => {
+    router.push(`/cms/exercises`);
+  }
+
 
   return (
     <Box>
@@ -169,38 +186,17 @@ export default function DetailExercise({ id, onArchive, isEditing }: Props) {
       </Box>
 
       <Box sx={actionsContainerStyles}>
-        {isEditing ? (
-          <>
-            <Button
-              variant="outlined"
-              sx={{
-                ...cancelButtonStyles(muiTheme),
-                borderColor: "red",
-                color: "red",
-                "&:hover": { borderColor: "darkred" },
-              }}
-              onClick={handleCancel}
-            >
-              CANCELAR
-            </Button>
-
-            <Button
-              variant="contained"
-              sx={{ backgroundColor: "#004A7C", "&:hover": { backgroundColor: "#003B63" } }}
-              onClick={handleSave}
-            >
-              SALVAR
-            </Button>
-          </>
-        ) : (
-          <Button
-            variant="contained"
-            sx={returnToList(muiTheme)}
-            onClick={() => router.push("/cms/exercises")}
-          >
-            VOLTAR PARA LISTA
-          </Button>
-        )}
+        <FormActions
+          isValid={!!formData?.title && !!formData?.description && !!formData?.shortDescription}
+          isDirty={JSON.stringify(formData) !== JSON.stringify(exercise)}
+          mode={isEditing ? "edit" : "view"}
+          entityPath="cms/exercises"
+          entityId={id}
+          onSave={handleSave}
+          onCancel={handleCancel}
+          onEdit={handleEdit}
+          onBack={handleBack}
+        />
       </Box>
     </Box>
   );

--- a/src/components/PageElements/cms/exercises/detail-exercise.tsx
+++ b/src/components/PageElements/cms/exercises/detail-exercise.tsx
@@ -84,13 +84,14 @@ export default function DetailExercise({ id, onArchive, isEditing }: Props) {
   };
   
   const handleCancel = () => {
-    router.push(`/cms/exercises/${id}`);
     const confirmCancel = window.confirm(
       "Deseja cancelar a edição? As alterações serão perdidas."
     );
     if (!confirmCancel) {
       return;
     }
+
+    router.push(`/cms/exercises/${id}`);
   };
 
   const handleEdit = () => {

--- a/src/components/PageElements/cms/exercises/detail-exercise.tsx
+++ b/src/components/PageElements/cms/exercises/detail-exercise.tsx
@@ -94,7 +94,8 @@ export default function DetailExercise({ id, onArchive, isEditing }: Props) {
   };
 
   const handleEdit = () => {
-    router.push(`/cms/exercises/${id}/edit`);
+    /*router.push(`/cms/exercises/${id}/edit`);*/
+    
   }
 
   const handleBack = () => {

--- a/src/components/PageElements/cms/themes/detail-theme.tsx
+++ b/src/components/PageElements/cms/themes/detail-theme.tsx
@@ -62,10 +62,10 @@ export default function DetailTheme({ id }: Props) {
   }
 
   function handleEdit() {
-    /*setOriginalTheme(theme);
+    setOriginalTheme(theme);
     setIsEditing(true);
-    setErrorMessage("");*/
-    router.push(`/cms/themes/${id}/edit`);
+    setErrorMessage("");
+    /*router.push(`/cms/themes/${id}/edit`);*/
   }
 
   function handleCancelEdit() {

--- a/src/components/PageElements/cms/themes/detail-theme.tsx
+++ b/src/components/PageElements/cms/themes/detail-theme.tsx
@@ -6,10 +6,13 @@ import { UpperBanner } from "@/components/UI/cms/upper-banner";
 import {
   actionsContainerStyles,
   cancelButtonStyles,
+  returnToList,
   textFieldStyles,
   textFieldsContainerStyles,
 } from "@/components/UI/dashboard/forms/form.styles";
 import { CmsTheme } from "@/types/type";
+import { useRouter } from "next/navigation";
+import { useTheme } from "@mui/material";
 
 interface Props {
   id: string;
@@ -20,6 +23,8 @@ export default function DetailTheme({ id }: Props) {
   const [originalTheme, setOriginalTheme] = useState<CmsTheme | undefined>(undefined);
   const [isEditing, setIsEditing] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
+
+  const router = useRouter();
 
   const fetchTheme = useCallback(async () => {
     try {
@@ -129,6 +134,7 @@ export default function DetailTheme({ id }: Props) {
         title="Themes"
         showBreadCrumb
         breadCrumbLabel={theme?.title}
+        editButton={!isEditing}
       />
 
       {errorMessage && (
@@ -144,7 +150,7 @@ export default function DetailTheme({ id }: Props) {
           fullWidth
           InputProps={{ readOnly: !isEditing }}
           onChange={(event) => handleChange("title", event.target.value)}
-          sx={currentTextFieldStyles}
+          sx={textFieldStyles}
         />
 
         <TextField
@@ -153,7 +159,7 @@ export default function DetailTheme({ id }: Props) {
           fullWidth
           InputProps={{ readOnly: !isEditing }}
           onChange={(event) => handleChange("shortDescription", event.target.value)}
-          sx={currentTextFieldStyles}
+          sx={textFieldStyles}
         />
 
         <TextField
@@ -164,7 +170,7 @@ export default function DetailTheme({ id }: Props) {
           onChange={(event) => handleChange("description", event.target.value)}
           multiline
           rows={4}
-          sx={currentTextFieldStyles}
+          sx={textFieldStyles}
         />
 
         <TextField
@@ -173,7 +179,7 @@ export default function DetailTheme({ id }: Props) {
           fullWidth
           InputProps={{ readOnly: !isEditing }}
           onChange={(event) => handleChange("imageAlt", event.target.value)}
-          sx={currentTextFieldStyles}
+          sx={textFieldStyles}
         />
 
         <TextField
@@ -182,7 +188,7 @@ export default function DetailTheme({ id }: Props) {
           fullWidth
           InputProps={{ readOnly: !isEditing }}
           onChange={(event) => handleChange("category", event.target.value)}
-          sx={currentTextFieldStyles}
+          sx={textFieldStyles}
         />
 
         <TextField
@@ -191,15 +197,23 @@ export default function DetailTheme({ id }: Props) {
           fullWidth
           InputProps={{ readOnly: !isEditing }}
           onChange={(event) => handleChange("sequence", event.target.value)}
-          sx={currentTextFieldStyles}
+          sx={textFieldStyles}
         />
       </Box>
 
       <Box sx={actionsContainerStyles}>
         {!isEditing ? (
-          <Button onClick={handleEdit} disabled={!theme} variant="contained">
-            EDITAR
-          </Button>
+          <>
+            <Button onClick={handleEdit} disabled={!theme} variant="contained">
+              EDITAR
+            </Button>
+            
+            <Button
+              variant="contained"
+              onClick={() => router.push(`/cms/themes`)}>
+                        VOLTAR PARA LISTA
+            </Button>
+          </>
         ) : (
           <>
             <Button

--- a/src/components/PageElements/cms/themes/detail-theme.tsx
+++ b/src/components/PageElements/cms/themes/detail-theme.tsx
@@ -17,12 +17,13 @@ import { FormActions } from "@/components/UI/dashboard/forms/form-actions";
 
 interface Props {
   id: string;
+  isEditing?: boolean;
 }
 
-export default function DetailTheme({ id }: Props) {
+export default function DetailTheme({ id, isEditing }: Props) {
   const [theme, setTheme] = useState<CmsTheme | undefined>(undefined);
   const [originalTheme, setOriginalTheme] = useState<CmsTheme | undefined>(undefined);
-  const [isEditing, setIsEditing] = useState(false);
+  /*const [isEditing, setIsEditing] = useState(false);*/
   const [errorMessage, setErrorMessage] = useState("");
 
   const router = useRouter();
@@ -62,25 +63,20 @@ export default function DetailTheme({ id }: Props) {
   }
 
   function handleEdit() {
-    setOriginalTheme(theme);
-    setIsEditing(true);
-    setErrorMessage("");
-    /*router.push(`/cms/themes/${id}/edit`);*/
+    router.push(`/cms/themes/${id}/edit`);
   }
 
-  function handleCancelEdit() {
+  function handleCancel() {
+    router.push(`/cms/themes/${id}`);
     const confirmCancel = window.confirm(
       "Deseja cancelar a edição? As alterações serão perdidas."
     );
-
-    if (!confirmCancel) return;
-
-    setTheme(originalTheme);
-    setIsEditing(false);
-    setErrorMessage("");
+    if (!confirmCancel) {
+      return;
+    }
   }
 
-  async function handleSave() {
+  const handleSave = async () => {
     if (!theme) return;
 
     try {
@@ -110,9 +106,10 @@ export default function DetailTheme({ id }: Props) {
 
       const data = await response.json();
 
+      router.push("/cms/themes");
+
       setTheme(data.data ?? theme);
       setOriginalTheme(data.data ?? theme);
-      setIsEditing(false);
     } catch (error) {
       console.error("Erro ao salvar tema:", error);
       setErrorMessage("Não foi possível salvar as alterações do tema. Tente novamente.");
@@ -199,16 +196,16 @@ const handleBack = () => {
       <Box sx={actionsContainerStyles}>
               <FormActions
                 isValid={!!theme?.title && !!theme?.shortDescription && !!theme?.description}
-                isDirty={JSON.stringify(theme) !== JSON.stringify(theme)}
+                isDirty={JSON.stringify(theme) !== JSON.stringify(originalTheme)}
                 mode={isEditing ? "edit" : "view"}
                 entityPath="cms/themes"
                 entityId={id}
                 onSave={handleSave}
-                onCancel={handleCancelEdit}
+                onCancel={handleCancel}
                 onEdit={handleEdit}
                 onBack={handleBack}
               />
-            </Box>
+      </Box>
     </Box>
   );
 }

--- a/src/components/PageElements/cms/themes/detail-theme.tsx
+++ b/src/components/PageElements/cms/themes/detail-theme.tsx
@@ -67,13 +67,15 @@ export default function DetailTheme({ id, isEditing }: Props) {
   }
 
   function handleCancel() {
-    router.push(`/cms/themes/${id}`);
+
     const confirmCancel = window.confirm(
       "Deseja cancelar a edição? As alterações serão perdidas."
     );
     if (!confirmCancel) {
       return;
     }
+
+        router.push(`/cms/themes/${id}`);
   }
 
   const handleSave = async () => {

--- a/src/components/PageElements/cms/themes/detail-theme.tsx
+++ b/src/components/PageElements/cms/themes/detail-theme.tsx
@@ -13,6 +13,7 @@ import {
 import { CmsTheme } from "@/types/type";
 import { useRouter } from "next/navigation";
 import { useTheme } from "@mui/material";
+import { FormActions } from "@/components/UI/dashboard/forms/form-actions";
 
 interface Props {
   id: string;
@@ -61,9 +62,10 @@ export default function DetailTheme({ id }: Props) {
   }
 
   function handleEdit() {
-    setOriginalTheme(theme);
+    /*setOriginalTheme(theme);
     setIsEditing(true);
-    setErrorMessage("");
+    setErrorMessage("");*/
+    router.push(`/cms/themes/${id}/edit`);
   }
 
   function handleCancelEdit() {
@@ -117,16 +119,9 @@ export default function DetailTheme({ id }: Props) {
     }
   }
 
-  const currentTextFieldStyles = {
-    ...textFieldStyles,
-    ...(isEditing
-      ? {}
-      : {
-          "& .MuiOutlinedInput-notchedOutline": {
-            border: "none",
-          },
-        }),
-  };
+const handleBack = () => {
+    router.push(`/cms/themes`);
+  }
 
   return (
     <Box>
@@ -202,38 +197,18 @@ export default function DetailTheme({ id }: Props) {
       </Box>
 
       <Box sx={actionsContainerStyles}>
-        {!isEditing ? (
-          <>
-            <Button onClick={handleEdit} disabled={!theme} variant="contained">
-              EDITAR
-            </Button>
-            
-            <Button
-              variant="contained"
-              onClick={() => router.push(`/cms/themes`)}>
-                        VOLTAR PARA LISTA
-            </Button>
-          </>
-        ) : (
-          <>
-            <Button
-              variant="outlined"
-              sx={cancelButtonStyles}
-              onClick={handleCancelEdit}
-            >
-              CANCELAR
-            </Button>
-
-            <Button
-              variant="contained"
-              onClick={handleSave}
-              disabled={!theme}
-            >
-              SALVAR
-            </Button>
-          </>
-        )}
-      </Box>
+              <FormActions
+                isValid={!!theme?.title && !!theme?.shortDescription && !!theme?.description}
+                isDirty={JSON.stringify(theme) !== JSON.stringify(theme)}
+                mode={isEditing ? "edit" : "view"}
+                entityPath="cms/themes"
+                entityId={id}
+                onSave={handleSave}
+                onCancel={handleCancelEdit}
+                onEdit={handleEdit}
+                onBack={handleBack}
+              />
+            </Box>
     </Box>
   );
 }

--- a/src/components/PageElements/cms/topics/detail-topic.tsx
+++ b/src/components/PageElements/cms/topics/detail-topic.tsx
@@ -25,6 +25,7 @@ import { fi } from "zod/v4/locales";
 
 interface Props {
   id: string;
+  isEditing?: boolean;
 }
 
 const getYouTubeEmbedUrl = (url: string) => {
@@ -37,10 +38,10 @@ const getYouTubeEmbedUrl = (url: string) => {
   return `https://www.youtube.com/embed/${videoId}`;
 };
 
-export default function DetailTopic({ id }: Props) {
+export default function DetailTopic({ id, isEditing }: Props) {
   const [topic, setTopic] = useState<CmsTopic | undefined>(undefined);
   const [originalTopic, setOriginalTopic] = useState<CmsTopic | undefined>(undefined)
-  const [isEditing, setIsEditing] = useState(false);
+  /*const [isEditing, setIsEditing] = useState(false);*/
   const [loading, setLoading] = useState(true);
   const [errorStatus, setErrorStatus] = useState<number | null>(null);
   const [errorMessage, setErrorMessage] = useState("")
@@ -104,12 +105,11 @@ export default function DetailTopic({ id }: Props) {
   }
 
   function handleEdit() {
-    setOriginalTopic(topic)
-    setIsEditing(true)
-    setErrorMessage("")
+    router.push(`/cms/topics/${id}/edit`);
   }
   
-function handleCancelEdit() {
+function handleCancel() {
+  router.push(`/cms/topics/${id}`);
     const confirmCancel = window.confirm(
       "Deseja cancelar a edição? As alterações serão perdidas."
     )
@@ -117,7 +117,6 @@ function handleCancelEdit() {
     if (!confirmCancel) return
 
     setTopic(originalTopic)
-    setIsEditing(false)
     setErrorMessage("")
   }
 
@@ -133,10 +132,10 @@ function handleCancelEdit() {
         shortDescription: topic.shortDescription,
         description: topic.description,
         isActive: topic.isActive,
-        videoTitle: topic.video?.title,
+        /*videoTitle: topic.video?.title,
         videoDescription: topic.video?.description,
         videoReferences: topic.video?.references,
-        videoLink: topic.video?.link,
+        videoLink: topic.video?.link,*/
       }
 
       const response = await fetch("/api/topics/updateTopic", {
@@ -154,15 +153,20 @@ function handleCancelEdit() {
 
     const data = await response.json()
 
+    router.push("/cms/topics");
+
     setTopic(data.data ?? topic)
     setOriginalTopic(data.data ?? topic)
-    setIsEditing(false)
   } catch (error) {
       console.error("Erro ao salvar tópico:", error);
       setErrorMessage("Ocorreu um erro ao salvar o tópico. Por favor, tente novamente.");
     }
 
 }
+
+const handleBack = () => {
+    router.push(`/cms/topics`);
+  }
 
 
 /*   if (loading) return <Loading />;
@@ -319,46 +323,6 @@ function handleCancelEdit() {
               sx={textFieldStyles}
             />
 
-            {isEditing && (
-                      <Box
-                        sx={{
-                          display: "flex",
-                          justifyContent: "flex-end",
-                          gap: 2,
-                          mt: 4,
-                        }}
-                      >
-                        <Button
-                          variant="outlined"
-                          sx={{
-                            ...cancelButtonStyles(muiTheme),
-                            borderColor: "red",
-                            color: "red",
-                            backgroundColor: "#fff",
-                            px: 4,
-                          }}
-                          onClick={handleCancelEdit}
-                        >
-                          CANCELAR
-                        </Button>
-            
-                        <Button
-                          variant="contained"
-                          onClick={handleSave}
-                          disabled={!topic}
-                          sx={{
-                            backgroundColor: "#004A7C",
-                            px: 4,
-                            "&:hover": {
-                              backgroundColor: "#003B63",
-                            },
-                          }}
-                        >
-                          SALVAR
-                        </Button>
-                      </Box>
-                    )}
-
             {/* {videoEmbedUrl ? (
               <Box sx={{ width: "100%", overflow: "hidden", borderRadius: 2 }}>
                 <iframe
@@ -380,6 +344,20 @@ function handleCancelEdit() {
         ) : (
           <Typography variant="body1">Nenhum vídeo cadastrado para este tópico.</Typography>
         )}
+      </Box>
+
+      <Box sx={actionsContainerStyles}>
+              <FormActions
+                isValid={!!topic?.title && !!topic?.shortDescription && !!topic?.description}
+                isDirty={JSON.stringify(topic) !== JSON.stringify(originalTopic)}
+                mode={isEditing ? "edit" : "view"}
+                entityPath="cms/topics"
+                entityId={id}
+                onSave={handleSave}
+                onCancel={handleCancel}
+                onEdit={handleEdit}
+                onBack={handleBack}
+              />
       </Box>
 
   

--- a/src/components/PageElements/cms/topics/detail-topic.tsx
+++ b/src/components/PageElements/cms/topics/detail-topic.tsx
@@ -109,7 +109,6 @@ export default function DetailTopic({ id, isEditing }: Props) {
   }
   
 function handleCancel() {
-  router.push(`/cms/topics/${id}`);
     const confirmCancel = window.confirm(
       "Deseja cancelar a edição? As alterações serão perdidas."
     )
@@ -118,6 +117,8 @@ function handleCancel() {
 
     setTopic(originalTopic)
     setErrorMessage("")
+    
+    router.push(`/cms/topics/${id}`);
   }
 
   /* Começa aqui */

--- a/src/components/UI/dashboard/forms/form-actions.tsx
+++ b/src/components/UI/dashboard/forms/form-actions.tsx
@@ -87,8 +87,9 @@ export function FormActions({
           <Button
             variant="contained"
             sx={cancelButtonStyles(theme)}
-            onClick={() => router.push(`/${entityPath}/${entityId}`)
-  }
+            onClick={() =>
+        onCancel ? onCancel() : router.push(`/${entityPath}`)
+      }
           >
             Cancelar
           </Button>

--- a/src/components/UI/dashboard/forms/form-actions.tsx
+++ b/src/components/UI/dashboard/forms/form-actions.tsx
@@ -14,6 +14,10 @@ interface FormActionsProps {
   mode: "create" | "edit" | "view";
   entityPath: string;
   entityId?: string;
+  onSave?: () => void;
+  onCancel?: () => void;
+  onEdit?: () => void;
+  onBack?: () => void;
 }
 
 export function FormActions({
@@ -22,6 +26,10 @@ export function FormActions({
   mode,
   entityPath,
   entityId,
+  onSave,
+  onCancel,
+  onEdit,
+  onBack
 }: FormActionsProps) {
   const theme = useTheme();
   const router = useRouter();
@@ -33,7 +41,9 @@ export function FormActions({
           <Button
             variant="contained"
             sx={returnToList(theme)}
-            onClick={() => router.push(`/${entityPath}/${entityId}/edit`)}
+            onClick={() =>
+    onEdit ? onEdit() : router.push(`/${entityPath}/${entityId}/edit`)
+  }
           >
             Editar
           </Button>
@@ -41,7 +51,7 @@ export function FormActions({
           <Button
             variant="contained"
             sx={returnToList(theme)}
-            onClick={() => router.push(`/${entityPath}`)}
+            onClick={() => (onBack ? onBack() : router.push(`/${entityPath}`))}
           >
             VOLTAR PARA LISTA
           </Button>
@@ -53,16 +63,19 @@ export function FormActions({
           <Button
             variant="contained"
             sx={cancelButtonStyles(theme)}
-            onClick={() => router.push(`/${entityPath}/${entityId}`)}
+            onClick={() =>
+    onCancel ? onCancel() : router.push(mode === "edit" ? `/${entityPath}/${entityId}` : `/${entityPath}`)
+  }
           >
             Cancelar
           </Button>
 
           <Button
-            type="submit"
+            type={onSave ? "button" : "submit"}
             variant="contained"
             disabled={!isDirty || !isValid}
             sx={submitButtonStyles(theme)}
+            onClick={onSave}
           >
             Salvar
           </Button>
@@ -74,7 +87,8 @@ export function FormActions({
           <Button
             variant="contained"
             sx={cancelButtonStyles(theme)}
-            onClick={() => router.push(`/${entityPath}`)}
+            onClick={() => router.push(`/${entityPath}/${entityId}`)
+  }
           >
             Cancelar
           </Button>
@@ -84,6 +98,7 @@ export function FormActions({
             variant="contained"
             disabled={!isDirty || !isValid}
             sx={submitButtonStyles(theme)}
+            onClick={onSave}
           >
             Salvar
           </Button>


### PR DESCRIPTION
#345  -fix: padronizar ações de formulário, botões e correção de css

====
  
### 🆙 CHANGELOG

### Atividades

- Implementada rota de edição para tema por id.
- Ajustada rota de edição de tópicos para reutilizar o componente de detalhes em modo de edição.
- Refatoradas ações de formulário para suportar callbacks customizados de salvar, cancelar, editar e voltar para lista.
- Unificado o uso do componente de ações nas telas de detalhe de temas, tópicos e exercícios.
- Padronizado o botão Voltar para Lista e o comportamento de navegação entre visualização e edição.
- Ajustado controle de estado de edição para funcionar por rota (view/edit), reduzindo inconsistências entre telas.

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [ ] Acessar CMS de Temas, abrir um item e validar: Editar, Salvar, Cancelar e Voltar para Lista.
- [ ] Acessar CMS de Tópicos, abrir um item e validar o mesmo fluxo em modo visualização e edição.
- [ ] Acessar CMS de Exercícios, abrir detalhe e validar ações padronizadas.
- [ ] Confirmar redirecionamento correto após salvar em cada entidade.
- [ ] Confirmar que a navegação entre detalhe e edição ocorre sem inconsistência visual ou funcional.