### PR TITLE
fix: standardize Portuguese nomenclature across components

### DIFF
--- a/src/components/BreadCrumb/index.tsx
+++ b/src/components/BreadCrumb/index.tsx
@@ -9,6 +9,13 @@ type BreadCrumbProps = {
   lastLabel?: string;
 };
 
+const translations: Record<string, string> = {
+  themes: 'Temas',
+  topics: 'Tópicos',
+  exercises: 'Exercícios',
+  cms: 'Admin',
+};
+
 export const BreadCrumb: React.FC<BreadCrumbProps> = ({ lastLabel }) => {
   const pathname: string = usePathname();
   const [isValidPage, setIsValidPage] = useState<boolean>(false);
@@ -39,7 +46,9 @@ export const BreadCrumb: React.FC<BreadCrumbProps> = ({ lastLabel }) => {
     .filter((crumb) => crumb)
     .map((crumb) => {
       const hyphenIndex = crumb.indexOf('-');
-      return hyphenIndex !== -1 ? crumb.substring(hyphenIndex + 1) : crumb;
+      const rawText = hyphenIndex !== -1 ? crumb.substring(hyphenIndex + 1) : crumb;
+
+      return translations[rawText.toLowerCase()] || rawText;
     });
 
   if (lastLabel && breadcrumbs.length > 0) {

--- a/src/components/PageElements/cms/exercises/detail-exercise.tsx
+++ b/src/components/PageElements/cms/exercises/detail-exercise.tsx
@@ -108,7 +108,7 @@ export default function DetailExercise({ id, onArchive, isEditing }: Props) {
     <Box>
       <Box sx={{ position: "relative" }}>
         <UpperBanner
-          title={exercise?.title || "Exercícios"}
+          title={"Exercícios"}
           showBreadCrumb
           breadCrumbLabel={exercise?.title}
           editButton={!isEditing}

--- a/src/components/PageElements/cms/exercises/render-exercises.tsx
+++ b/src/components/PageElements/cms/exercises/render-exercises.tsx
@@ -56,7 +56,7 @@ export default function RenderCmsPage() {
       sx={{ width: "100%" }}
     >
       <UpperBanner
-        title="CMS - Exercícios"
+        title="Admin - Exercícios"
         menuBanner
         createButton
         showBreadCrumb

--- a/src/components/PageElements/cms/themes/detail-theme.tsx
+++ b/src/components/PageElements/cms/themes/detail-theme.tsx
@@ -125,7 +125,7 @@ const handleBack = () => {
   return (
     <Box>
       <UpperBanner
-        title="Themes"
+        title="Temas"
         showBreadCrumb
         breadCrumbLabel={theme?.title}
         editButton={!isEditing}

--- a/src/components/PageElements/cms/themes/render-theme.tsx
+++ b/src/components/PageElements/cms/themes/render-theme.tsx
@@ -40,7 +40,7 @@ export default function RenderCmsPage() {
       sx={{ width: "100%"}}
     >
       <UpperBanner 
-        title="CMS - Temas"   
+        title="Admin - Temas"   
         menuBanner 
         createButton
         showBreadCrumb

--- a/src/components/PageElements/cms/topics/detail-topic.tsx
+++ b/src/components/PageElements/cms/topics/detail-topic.tsx
@@ -123,7 +123,7 @@ export default function DetailTopic({ id, isEditing }: Props) {
     <Box>
       <Box sx={{ position: "relative" }}>
         <UpperBanner
-          title={topic?.title || "Tópicos"}
+          title={"Tópicos"}
           showBreadCrumb
           breadCrumbLabel={topic?.title}
           editButton={!isEditing}

--- a/src/components/PageElements/cms/topics/render-topic.tsx
+++ b/src/components/PageElements/cms/topics/render-topic.tsx
@@ -57,7 +57,7 @@ export default function RenderCmsPage() {
       sx={{ width: "100%" }}
     >
       <UpperBanner
-        title="CMS - Tópicos"
+        title="Admin - Tópicos"
         menuBanner
         createButton
         showBreadCrumb


### PR DESCRIPTION
#356  - fix: padronizar nomenclatura portugues (cms -> admin, themes -> temas, ...)
====
  
### 🆙 CHANGELOG

*Esses passos são apenas exemplos*

- Substitui o termo "exercises" por "exercícios".
- Substitui o termo "themes" por "temas".
- Substitui o termo "topics" por "tópicos".
- Substitui o termo "cms" por "admin".

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

*Esses passos são apenas exemplos*

- [ ] Fazer deploy em ambiente de teste
- [ ] Abrir URL da aplicação de teste
- [ ] Acessar lista de temas e visualizar um tema
- [ ] Acessar lista de exercícios e visualizar um exercício
- [ ] Acessar lista de tópicos e visualizar um tópico
- [ ] Aplicação não deve conter nenhum erro, warning ou console.log
- [ ] Alteração proposta no card foi implementada
