### PR TITLE
refactor: padroniza textos e remove botões desnecessários nos compone…

### DIFF
--- a/src/components/PageElements/cms/themes/detail-theme.tsx
+++ b/src/components/PageElements/cms/themes/detail-theme.tsx
@@ -1,18 +1,15 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { Alert, Box, Button, TextField } from "@mui/material";
+import { Alert, Box, TextField } from "@mui/material";
 import { UpperBanner } from "@/components/UI/cms/upper-banner";
 import {
   actionsContainerStyles,
-  cancelButtonStyles,
-  returnToList,
   textFieldStyles,
   textFieldsContainerStyles,
 } from "@/components/UI/dashboard/forms/form.styles";
 import { CmsTheme } from "@/types/type";
 import { useRouter } from "next/navigation";
-import { useTheme } from "@mui/material";
 import { FormActions } from "@/components/UI/dashboard/forms/form-actions";
 
 interface Props {
@@ -23,7 +20,6 @@ interface Props {
 export default function DetailTheme({ id, isEditing }: Props) {
   const [theme, setTheme] = useState<CmsTheme | undefined>(undefined);
   const [originalTheme, setOriginalTheme] = useState<CmsTheme | undefined>(undefined);
-  /*const [isEditing, setIsEditing] = useState(false);*/
   const [errorMessage, setErrorMessage] = useState("");
 
   const router = useRouter();
@@ -125,7 +121,7 @@ const handleBack = () => {
   return (
     <Box>
       <UpperBanner
-        title="Themes"
+        title={theme?.title || "Temas"}
         showBreadCrumb
         breadCrumbLabel={theme?.title}
         editButton={!isEditing}

--- a/src/components/PageElements/cms/topics/detail-topic.tsx
+++ b/src/components/PageElements/cms/topics/detail-topic.tsx
@@ -2,12 +2,10 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Box, Button, TextField, Typography, useTheme } from "@mui/material";
+import { Box, TextField, useTheme } from "@mui/material";
 import { UpperBanner } from "@/components/UI/cms/upper-banner";
 import {
   actionsContainerStyles,
-  cancelButtonStyles,
-  returnToList,
   textFieldStyles,
   textFieldsContainerStyles,
 } from "@/components/UI/dashboard/forms/form.styles";
@@ -44,6 +42,7 @@ export default function DetailTopic({ id, isEditing }: Props) {
 
       const data = await response.json();
       setTopic(data.data);
+      setOriginalTopic(data.data);
       setFormData(data.data);
     } catch (error) {
       console.error("Erro ao buscar tópico:", error);
@@ -97,9 +96,17 @@ export default function DetailTopic({ id, isEditing }: Props) {
 
 }
 
-  const handleCancel = () => {
-    router.push(`/cms/topics/${id}`);
-  };
+  function handleCancel() {
+
+    const confirmCancel = window.confirm(
+      "Deseja cancelar a edição? As alterações serão perdidas."
+    );
+    if (!confirmCancel) {
+      return;
+    }
+
+        router.push(`/cms/topics/${id}`);
+  }
 
   function handleEdit() {
     router.push(`/cms/topics/${id}/edit`);
@@ -240,9 +247,7 @@ export default function DetailTopic({ id, isEditing }: Props) {
 
       <Box sx={actionsContainerStyles}>
         <FormActions
-          isValid={
-            !!topic?.title && !!topic?.shortDescription && !!topic?.description
-          }
+          isValid={!!topic?.title && !!topic?.shortDescription && !!topic?.description}
           isDirty={JSON.stringify(topic) !== JSON.stringify(originalTopic)}
           mode={isEditing ? "edit" : "view"}
           entityPath="cms/topics"

--- a/src/components/UI/dashboard/forms/form-actions.tsx
+++ b/src/components/UI/dashboard/forms/form-actions.tsx
@@ -4,9 +4,8 @@ import {
   actionsBoxStyles,
   cancelButtonStyles,
   returnToList,
-  submitButtonStyles
-} from "../forms/form.styles"
-
+  submitButtonStyles,
+} from "../forms/form.styles";
 
 interface FormActionsProps {
   isValid: boolean;
@@ -29,7 +28,7 @@ export function FormActions({
   onSave,
   onCancel,
   onEdit,
-  onBack
+  onBack,
 }: FormActionsProps) {
   const theme = useTheme();
   const router = useRouter();
@@ -38,16 +37,6 @@ export function FormActions({
     <Box sx={actionsBoxStyles}>
       {mode === "view" && (
         <>
-          {/*<Button
-            variant="contained"
-            sx={returnToList(theme)}
-            onClick={() =>
-    onEdit ? onEdit() : router.push(`/${entityPath}/${entityId}/edit`)
-  }
-          >
-            Editar
-          </Button>*/}
-
           <Button
             variant="contained"
             sx={returnToList(theme)}
@@ -64,8 +53,14 @@ export function FormActions({
             variant="contained"
             sx={cancelButtonStyles(theme)}
             onClick={() =>
-    onCancel ? onCancel() : router.push(mode === "edit" ? `/${entityPath}/${entityId}` : `/${entityPath}`)
-  }
+              onCancel
+                ? onCancel()
+                : router.push(
+                    mode === "edit"
+                      ? `/${entityPath}/${entityId}`
+                      : `/${entityPath}`,
+                  )
+            }
           >
             Cancelar
           </Button>
@@ -88,8 +83,8 @@ export function FormActions({
             variant="contained"
             sx={cancelButtonStyles(theme)}
             onClick={() =>
-        onCancel ? onCancel() : router.push(`/${entityPath}`)
-      }
+              onCancel ? onCancel() : router.push(`/${entityPath}`)
+            }
           >
             Cancelar
           </Button>

--- a/src/components/UI/dashboard/forms/form-actions.tsx
+++ b/src/components/UI/dashboard/forms/form-actions.tsx
@@ -38,7 +38,7 @@ export function FormActions({
     <Box sx={actionsBoxStyles}>
       {mode === "view" && (
         <>
-          <Button
+          {/*<Button
             variant="contained"
             sx={returnToList(theme)}
             onClick={() =>
@@ -46,14 +46,14 @@ export function FormActions({
   }
           >
             Editar
-          </Button>
+          </Button>*/}
 
           <Button
             variant="contained"
             sx={returnToList(theme)}
             onClick={() => (onBack ? onBack() : router.push(`/${entityPath}`))}
           >
-            VOLTAR PARA LISTA
+            Voltar para a lista
           </Button>
         </>
       )}
@@ -101,7 +101,7 @@ export function FormActions({
             sx={submitButtonStyles(theme)}
             onClick={onSave}
           >
-            Salvar
+            Criar
           </Button>
         </>
       )}


### PR DESCRIPTION
#354 - fix:padronizar botões 
  
### 🆙 CHANGELOG

Padronização visual e lógica dos botões de ação nos fluxos de visualização, edição e criação de temas, tópicos e exercícios.

- Removida duplicidade da ação Editar na tela de visualização, mantendo um único ponto de ação para evitar ambiguidade de UX.
- Padronizados rótulos dos botões de ação entre os modos de formulário:
- Visualização: Voltar para lista
- Edição: Cancelar e Salvar
- Criação: Cancelar e Criar
- Ajustado texto em inglês remanescente na tela de tema para manter consistência de idioma no CMS.


## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

*Esses passos são apenas exemplos*

- [ ] Navegar até a página de listagem de temas/tópicos/exercícios;
- [ ] Clicar em um item para entrar na vizualização individual;
- [ ] Checar o visual e o comportamento de todos os botões na tela;
- [ ] Testar também o botão criar;
