### PR TITLE
359 fix melhorar breadcrumb

### DIFF
--- a/src/components/BreadCrumb/index.tsx
+++ b/src/components/BreadCrumb/index.tsx
@@ -41,15 +41,21 @@ export const BreadCrumb: React.FC<BreadCrumbProps> = ({ lastLabel }) => {
     checkPageStatus();
   }, [pathname]);
 
-  const breadcrumbs: string[] = pathname
-    .split('/')
-    .filter((crumb) => crumb)
-    .map((crumb) => {
-      const hyphenIndex = crumb.indexOf('-');
-      const rawText = hyphenIndex !== -1 ? crumb.substring(hyphenIndex + 1) : crumb;
+  const routeSegments: string[] = pathname.split('/').filter((crumb) => crumb);
+  const isEditPage: boolean = Boolean(lastLabel) && routeSegments.at(-1) === 'edit';
 
-      return translations[rawText.toLowerCase()] || rawText;
-    });
+  const breadcrumbs: string[] = [];
+
+  routeSegments.forEach((crumb, index) => {
+    if (isEditPage && index === routeSegments.length - 2) {
+      return;
+    }
+
+    const hyphenIndex = crumb.indexOf('-');
+    const rawText = hyphenIndex !== -1 ? crumb.substring(hyphenIndex + 1) : crumb;
+
+    breadcrumbs.push(translations[rawText.toLowerCase()] || rawText);
+  });
 
   if (lastLabel && breadcrumbs.length > 0) {
     breadcrumbs[breadcrumbs.length - 1] = lastLabel;
@@ -57,7 +63,7 @@ export const BreadCrumb: React.FC<BreadCrumbProps> = ({ lastLabel }) => {
 
   const capitalizeFirstLetter = (text: string): string => text.charAt(0).toUpperCase() + text.slice(1)
 
-  const breadroutes: string[] = pathname.split('/').filter((crumb) => crumb);
+  const breadroutes: string[] = routeSegments;
 
   const handleBreadcrumbClick = (href: string, event: MouseEvent<HTMLAnchorElement, globalThis.MouseEvent>) => {
     if (href === pathname) {

--- a/src/components/BreadCrumb/index.tsx
+++ b/src/components/BreadCrumb/index.tsx
@@ -16,6 +16,20 @@ const translations: Record<string, string> = {
   cms: 'Admin',
 };
 
+const breadcrumbTranslations: Record<string, string> = {
+  ...translations,
+  themeslist: 'Admin',
+  topicslist: 'Admin',
+  exerciseslist: 'Admin',
+};
+
+const breadcrumbCheck: Record<string, boolean> = {
+  themes: true,
+  topics: true,
+  exercises: true,
+  "": true,
+};
+
 export const BreadCrumb: React.FC<BreadCrumbProps> = ({ lastLabel }) => {
   const pathname: string = usePathname();
   const [isValidPage, setIsValidPage] = useState<boolean>(false);
@@ -43,27 +57,42 @@ export const BreadCrumb: React.FC<BreadCrumbProps> = ({ lastLabel }) => {
 
   const routeSegments: string[] = pathname.split('/').filter((crumb) => crumb);
   const isEditPage: boolean = Boolean(lastLabel) && routeSegments.at(-1) === 'edit';
+  
+  const normalizedSegments: string[] = routeSegments.map(segment => {
+    const match = segment.match(/^([^-]+)-/);
+    return match ? match[1] : segment;
+  });
+
+  const baseSegments: string[] = normalizedSegments.slice(0, 2);
+  
+  const isListPage: boolean = ['themes', 'topics', 'exercises'].includes(baseSegments[1]?.toLowerCase());
+
+  const visibleSegments: string[] = isListPage 
+    ? ['cms']
+    : lastLabel
+      ? routeSegments.slice(0, isEditPage ? -2 : -1)
+      : routeSegments;
 
   const breadcrumbs: string[] = [];
 
-  routeSegments.forEach((crumb, index) => {
-    if (isEditPage && index === routeSegments.length - 2) {
-      return;
-    }
-
+  visibleSegments.forEach((crumb) => {
     const hyphenIndex = crumb.indexOf('-');
     const rawText = hyphenIndex !== -1 ? crumb.substring(hyphenIndex + 1) : crumb;
-
-    breadcrumbs.push(translations[rawText.toLowerCase()] || rawText);
+    
+    const segmentKey = crumbsTranslate(rawText.toLowerCase());
+    breadcrumbs.push(breadcrumbTranslations[segmentKey] || translations[rawText.toLowerCase()] || rawText);
   });
 
-  if (lastLabel && breadcrumbs.length > 0) {
-    breadcrumbs[breadcrumbs.length - 1] = lastLabel;
+  function crumbsTranslate(segment: string): string {
+    if (breadcrumbTranslations[segment as keyof typeof breadcrumbTranslations] !== undefined) {
+      return segment as keyof typeof breadcrumbTranslations;
+    }
+    return segment;
   }
 
   const capitalizeFirstLetter = (text: string): string => text.charAt(0).toUpperCase() + text.slice(1)
 
-  const breadroutes: string[] = routeSegments;
+  const breadroutes: string[] = visibleSegments;
 
   const handleBreadcrumbClick = (href: string, event: MouseEvent<HTMLAnchorElement, globalThis.MouseEvent>) => {
     if (href === pathname) {

--- a/src/components/PageElements/cms/exercises/detail-exercise.tsx
+++ b/src/components/PageElements/cms/exercises/detail-exercise.tsx
@@ -108,7 +108,7 @@ export default function DetailExercise({ id, onArchive, isEditing }: Props) {
     <Box>
       <Box sx={{ position: "relative" }}>
         <UpperBanner
-          title={"Exercícios"}
+          title={exercise?.title || ""}
           showBreadCrumb
           breadCrumbLabel={exercise?.title}
           editButton={!isEditing}

--- a/src/components/PageElements/cms/exercises/render-exercises.tsx
+++ b/src/components/PageElements/cms/exercises/render-exercises.tsx
@@ -56,7 +56,7 @@ export default function RenderCmsPage() {
       sx={{ width: "100%" }}
     >
       <UpperBanner
-        title="Admin - Exercícios"
+        title="Exercícios"
         menuBanner
         createButton
         showBreadCrumb

--- a/src/components/PageElements/cms/themes/detail-theme.tsx
+++ b/src/components/PageElements/cms/themes/detail-theme.tsx
@@ -121,7 +121,7 @@ const handleBack = () => {
   return (
     <Box>
       <UpperBanner
-        title="Temas"
+        title={theme?.title || ""}
         showBreadCrumb
         breadCrumbLabel={theme?.title}
         editButton={!isEditing}

--- a/src/components/PageElements/cms/themes/detail-theme.tsx
+++ b/src/components/PageElements/cms/themes/detail-theme.tsx
@@ -21,6 +21,7 @@ export default function DetailTheme({ id, isEditing }: Props) {
   const [theme, setTheme] = useState<CmsTheme | undefined>(undefined);
   const [originalTheme, setOriginalTheme] = useState<CmsTheme | undefined>(undefined);
   const [errorMessage, setErrorMessage] = useState("");
+  const [formData, setFormData] = useState<CmsTheme | undefined>();
 
   const router = useRouter();
 
@@ -37,9 +38,9 @@ export default function DetailTheme({ id, isEditing }: Props) {
       if (!response.ok) throw new Error(`Erro: ${response.status}`);
 
       const data = await response.json();
-
       setTheme(data.data);
       setOriginalTheme(data.data);
+      setFormData(data.data);
     } catch (error) {
       console.error("Erro ao buscar tema:", error);
     }
@@ -50,10 +51,10 @@ export default function DetailTheme({ id, isEditing }: Props) {
   }, [fetchTheme]);
 
   function handleChange(field: keyof CmsTheme, value: string) {
-    if (!theme) return;
+    if (!formData) return;
 
-    setTheme({
-      ...theme,
+    setFormData({
+      ...formData,
       [field]: value,
     });
   }
@@ -63,7 +64,6 @@ export default function DetailTheme({ id, isEditing }: Props) {
   }
 
   function handleCancel() {
-
     const confirmCancel = window.confirm(
       "Deseja cancelar a edição? As alterações serão perdidas."
     );
@@ -71,22 +71,22 @@ export default function DetailTheme({ id, isEditing }: Props) {
       return;
     }
 
-        router.push(`/cms/themes/${id}`);
+    router.push(`/cms/themes/${id}`);
   }
 
-  const handleSave = async () => {
-    if (!theme) return;
+  const handleSave = useCallback(async () => {
+    if (!formData) return;
 
     try {
       setErrorMessage("");
 
       const payload = {
-        title: theme.title,
-        shortDescription: theme.shortDescription,
-        description: theme.description,
-        imageAlt: theme.imageAlt,
-        category: theme.category,
-        sequence: theme.sequence,
+        title: formData.title,
+        shortDescription: formData.shortDescription,
+        description: formData.description,
+        imageAlt: formData.imageAlt,
+        category: formData.category,
+        sequence: formData.sequence,
       };
 
       const response = await fetch(`/api/themes/updateTheme`, {
@@ -106,17 +106,18 @@ export default function DetailTheme({ id, isEditing }: Props) {
 
       router.push("/cms/themes");
 
-      setTheme(data.data ?? theme);
-      setOriginalTheme(data.data ?? theme);
+      setTheme(data.data);
+      setOriginalTheme(data.data);
+      setFormData(data.data);
     } catch (error) {
       console.error("Erro ao salvar tema:", error);
       setErrorMessage("Não foi possível salvar as alterações do tema. Tente novamente.");
     }
-  }
+  }, [formData, theme, id]);
 
-const handleBack = () => {
+  const handleBack = () => {
     router.push(`/cms/themes`);
-  }
+  };
 
   return (
     <Box>
@@ -136,7 +137,7 @@ const handleBack = () => {
       <Box sx={textFieldsContainerStyles}>
         <TextField
           label="Título"
-          value={theme?.title || ""}
+          value={formData?.title || ""}
           fullWidth
           InputProps={{ readOnly: !isEditing }}
           onChange={(event) => handleChange("title", event.target.value)}
@@ -145,7 +146,7 @@ const handleBack = () => {
 
         <TextField
           label="Descrição curta"
-          value={theme?.shortDescription || ""}
+          value={formData?.shortDescription || ""}
           fullWidth
           InputProps={{ readOnly: !isEditing }}
           onChange={(event) => handleChange("shortDescription", event.target.value)}
@@ -154,7 +155,7 @@ const handleBack = () => {
 
         <TextField
           label="Descrição"
-          value={theme?.description || ""}
+          value={formData?.description || ""}
           fullWidth
           InputProps={{ readOnly: !isEditing }}
           onChange={(event) => handleChange("description", event.target.value)}
@@ -165,7 +166,7 @@ const handleBack = () => {
 
         <TextField
           label="Texto alt da imagem"
-          value={theme?.imageAlt || ""}
+          value={formData?.imageAlt || ""}
           fullWidth
           InputProps={{ readOnly: !isEditing }}
           onChange={(event) => handleChange("imageAlt", event.target.value)}
@@ -174,7 +175,7 @@ const handleBack = () => {
 
         <TextField
           label="Categoria"
-          value={theme?.category || ""}
+          value={formData?.category || ""}
           fullWidth
           InputProps={{ readOnly: !isEditing }}
           onChange={(event) => handleChange("category", event.target.value)}
@@ -183,7 +184,7 @@ const handleBack = () => {
 
         <TextField
           label="Sequência"
-          value={theme?.sequence ?? ""}
+          value={formData?.sequence ?? ""}
           fullWidth
           InputProps={{ readOnly: !isEditing }}
           onChange={(event) => handleChange("sequence", event.target.value)}
@@ -192,17 +193,17 @@ const handleBack = () => {
       </Box>
 
       <Box sx={actionsContainerStyles}>
-              <FormActions
-                isValid={!!theme?.title && !!theme?.shortDescription && !!theme?.description}
-                isDirty={JSON.stringify(theme) !== JSON.stringify(originalTheme)}
-                mode={isEditing ? "edit" : "view"}
-                entityPath="cms/themes"
-                entityId={id}
-                onSave={handleSave}
-                onCancel={handleCancel}
-                onEdit={handleEdit}
-                onBack={handleBack}
-              />
+        <FormActions
+          isValid={!!formData?.title && !!formData?.shortDescription && !!formData?.description}
+          isDirty={JSON.stringify(formData) !== JSON.stringify(originalTheme)}
+          mode={isEditing ? "edit" : "view"}
+          entityPath="cms/themes"
+          entityId={id}
+          onSave={handleSave}
+          onCancel={handleCancel}
+          onEdit={handleEdit}
+          onBack={handleBack}
+        />
       </Box>
     </Box>
   );

--- a/src/components/PageElements/cms/themes/render-theme.tsx
+++ b/src/components/PageElements/cms/themes/render-theme.tsx
@@ -40,7 +40,7 @@ export default function RenderCmsPage() {
       sx={{ width: "100%"}}
     >
       <UpperBanner 
-        title="Admin - Temas"   
+        title="Temas"   
         menuBanner 
         createButton
         showBreadCrumb

--- a/src/components/PageElements/cms/topics/detail-topic.tsx
+++ b/src/components/PageElements/cms/topics/detail-topic.tsx
@@ -130,9 +130,9 @@ export default function DetailTopic({ id, isEditing }: Props) {
     <Box>
       <Box sx={{ position: "relative" }}>
         <UpperBanner
-          title={"Tópicos"}
+          title={topic?.title || ""}
           showBreadCrumb
-          breadCrumbLabel={topic?.title}
+          breadCrumbLabel={topic?.title || ""}
           editButton={!isEditing}
         />
       </Box>

--- a/src/components/PageElements/cms/topics/detail-topic.tsx
+++ b/src/components/PageElements/cms/topics/detail-topic.tsx
@@ -53,51 +53,45 @@ export default function DetailTopic({ id, isEditing }: Props) {
     fetchTopic();
   }, [fetchTopic]);
 
-  async function handleSave() {
-    if (!topic) return
+  const handleSave = useCallback(async () => {
+    if (!formData) return;
 
     try {
-      setErrorMessage("")
+      setErrorMessage("");
 
       const payload = {
-        title: topic.title,
-        shortDescription: topic.shortDescription,
-        description: topic.description,
-        isActive: topic.isActive,
-        /* videoTitle: topic.video?.title,
-        videoDescription: topic.video?.description,
-        videoReferences: topic.video?.references,
-        videoLink: topic.video?.link, */
-      }
+        title: formData.title,
+        shortDescription: formData.shortDescription,
+        description: formData.description,
+        isActive: topic?.isActive,
+      };
 
       const response = await fetch("/api/topics/updateTopic", {
-      method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        "id": String(id),
-      },
-      body: JSON.stringify(payload),
-    });
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "id": String(id),
+        },
+        body: JSON.stringify(payload),
+      });
 
-    if (!response.ok) {
-      throw new Error(`Erro: ${response.status}`)
-    }
+      if (!response.ok) {
+        throw new Error(`Erro: ${response.status}`);
+      }
 
-    const data = await response.json()
-
-    router.push("/cms/topics");
-
-    setTopic(data.data ?? topic)
-    setOriginalTopic(data.data ?? topic)
-  } catch (error) {
+      const data = await response.json();
+      router.push("/cms/topics");
+      
+      setTopic(data.data);
+      setOriginalTopic(data.data);
+      setFormData(data.data);
+    } catch (error) {
       console.error("Erro ao salvar tópico:", error);
       setErrorMessage("Ocorreu um erro ao salvar o tópico. Por favor, tente novamente.");
     }
-
-}
+  }, [formData, topic, id]);
 
   function handleCancel() {
-
     const confirmCancel = window.confirm(
       "Deseja cancelar a edição? As alterações serão perdidas."
     );
@@ -105,7 +99,7 @@ export default function DetailTopic({ id, isEditing }: Props) {
       return;
     }
 
-        router.push(`/cms/topics/${id}`);
+    router.push(`/cms/topics/${id}`);
   }
 
   function handleEdit() {
@@ -116,14 +110,13 @@ export default function DetailTopic({ id, isEditing }: Props) {
     router.push(`/cms/topics`);
   };
 
-  function handleChange(field: keyof CmsTopic , value: string) {
-    if (!topic) return
+  function handleChange(field: keyof CmsTopic, value: string) {
+    if (!formData) return;
 
-    setTopic({
-      ...topic,
+    setFormData({
+      ...formData,
       [field]: value,
-
-    })
+    });
   }
 
   return (
@@ -140,7 +133,7 @@ export default function DetailTopic({ id, isEditing }: Props) {
       <Box sx={textFieldsContainerStyles}>
         <TextField
           label="Título"
-          value={topic?.title || ""}
+          value={formData?.title || ""}
           onChange={(event) => handleChange("title", event.target.value)}
           InputProps={{ readOnly: !isEditing }}
           sx={textFieldStyles}
@@ -148,7 +141,7 @@ export default function DetailTopic({ id, isEditing }: Props) {
 
         <TextField
           label="Descrição"
-          value={topic?.description || ""}
+          value={formData?.description || ""}
           onChange={(event) => handleChange("description", event.target.value)}
           InputProps={{ readOnly: !isEditing }}
           multiline
@@ -158,7 +151,7 @@ export default function DetailTopic({ id, isEditing }: Props) {
 
         <TextField
           label="Descrição curta"
-          value={topic?.shortDescription || ""}
+          value={formData?.shortDescription || ""}
           onChange={(event) => handleChange("shortDescription", event.target.value)}
           InputProps={{ readOnly: !isEditing }}
           multiline
@@ -169,86 +162,86 @@ export default function DetailTopic({ id, isEditing }: Props) {
         {/* Campos para edição de vídeo */}
 
         {/* <TextField
-              label="Título do vídeo"
-              value={formData?.video?.title || ""}
-              onChange={(e) =>
-                setFormData((prev) => {
-                  prev ? {
-                    ...prev,
-                    video: {
-                      ...(prev.video || {}),
-                      title: e.target.value,
-                    },
-                  } : prev
-                })
-              }
-              InputProps={{ readOnly: !isEditing }}
-              rows={4}
-              sx={textFieldStyles}
-            />
+          label="Título do vídeo"
+          value={formData?.video?.title || ""}
+          onChange={(e) =>
+            setFormData((prev) => {
+              prev ? {
+                ...prev,
+                video: {
+                  ...(prev.video || {}),
+                  title: e.target.value,
+                },
+              } : prev
+            })
+          }
+          InputProps={{ readOnly: !isEditing }}
+          rows={4}
+          sx={textFieldStyles}
+        />
 
-            <TextField
-              label="Descrição do vídeo"
-              value={formData?.video?.description || ""}
-              onChange={(e) =>
-                setFormData((prev) => {
-                  prev ? {
-                    ...prev,
-                    video: {
-                      ...(prev.video || {}),
-                      description: e.target.value,
-                    },
-                  } : prev
-                })
-              }
-              InputProps={{ readOnly: !isEditing }}
-              
-              sx={textFieldStyles}
-            />
+        <TextField
+          label="Descrição do vídeo"
+          value={formData?.video?.description || ""}
+          onChange={(e) =>
+            setFormData((prev) => {
+              prev ? {
+                ...prev,
+                video: {
+                  ...(prev.video || {}),
+                  description: e.target.value,
+                },
+              } : prev
+            })
+          }
+          InputProps={{ readOnly: !isEditing }}
+          
+          sx={textFieldStyles}
+        />
 
-            <TextField
-              label="Referências do vídeo"
-              value={formData?.video?.references || ""}
-              onChange={(e) =>
-                setFormData((prev) => {
-                  prev ? {
-                    ...prev,
-                    video: {
-                      ...(prev.video || {}),
-                      references: e.target.value,
-                    },
-                  } : prev
-                })
-              }
-              InputProps={{ readOnly: !isEditing }}
-              rows={4}
-              sx={textFieldStyles}
-            />
+        <TextField
+          label="Referências do vídeo"
+          value={formData?.video?.references || ""}
+          onChange={(e) =>
+            setFormData((prev) => {
+              prev ? {
+                ...prev,
+                video: {
+                  ...(prev.video || {}),
+                  references: e.target.value,
+                },
+              } : prev
+            })
+          }
+          InputProps={{ readOnly: !isEditing }}
+          rows={4}
+          sx={textFieldStyles}
+        />
 
-            <TextField
-              label="Link do vídeo"
-              value={formData?.video?.link || ""}
-              onChange={(e) =>
-                setFormData((prev) => {
-                  prev ? {
-                    ...prev,
-                    video: {
-                      ...(prev.video || {}),
-                      link: e.target.value,
-                    },
-                  } : prev
-                })
-              }
-              InputProps={{ readOnly: !isEditing }}
-              rows={4}
-              sx={textFieldStyles}
-            /> */}
+        <TextField
+          label="Link do vídeo"
+          value={formData?.video?.link || ""}
+          onChange={(e) =>
+            setFormData((prev) => {
+              prev ? {
+                ...prev,
+                video: {
+                  ...(prev.video || {}),
+                  link: e.target.value,
+                },
+              } : prev
+            })
+          }
+          InputProps={{ readOnly: !isEditing }}
+          rows={4}
+          sx={textFieldStyles}
+        /> */}
       </Box>
 
       <Box sx={actionsContainerStyles}>
         <FormActions
-          isValid={!!topic?.title && !!topic?.shortDescription && !!topic?.description}
-          isDirty={JSON.stringify(topic) !== JSON.stringify(originalTopic)}
+          isValid={!!formData?.title && !!formData?.shortDescription && !!formData?.description}
+          isDirty={JSON.stringify(formData) !== JSON.stringify(originalTopic)}
           mode={isEditing ? "edit" : "view"}
           entityPath="cms/topics"
           entityId={id}

--- a/src/components/PageElements/cms/topics/render-topic.tsx
+++ b/src/components/PageElements/cms/topics/render-topic.tsx
@@ -57,7 +57,7 @@ export default function RenderCmsPage() {
       sx={{ width: "100%" }}
     >
       <UpperBanner
-        title="Admin - Tópicos"
+        title="Tópicos"
         menuBanner
         createButton
         showBreadCrumb


### PR DESCRIPTION
#359  - fix: melhorar breadcrumb
====
  
### 🆙 CHANGELOG

- BreadCrumb exibe o título do item ao invés do id 
- Removi a redundância de texto entre o BreadCrumb e o título da tela.

## ⚠️ Me certifico que:

- [ ] Não deixei nenhum novo warning, erro ou console.log nas minhas modificações
- [ ] Fiz deploy para ambiente de teste certificando que o build não quebrou
- [ ] Solicitei **code review** para 2 pessoas
- [ ] Solicitei **QA** para 2 pessoas
- [ ] Obtive aprovação de QA e posso fazer merge

## ⚠️ Como testar:

- [ ] Fazer deploy em ambiente de teste
- [ ] Abrir URL da aplicação de teste
- [ ] Acessar lista, entrar na edição de um item e verificar se o BreadCrumb não exibe o ID
- [ ] VAcessar lista e verificar se o BreadCrumb não duplica o título
- [ ] Aplicação não deve conter nenhum erro, warning ou console.log
- [ ] Alteração proposta no card foi implementada
